### PR TITLE
Fix lack of error handling on file removal failure during updates.

### DIFF
--- a/saltybox.go
+++ b/saltybox.go
@@ -154,7 +154,7 @@ func passphraseUpdateFile(plainfile string, cryptfile string, preader passphrase
 		return fmt.Errorf("failed to create tempfile: %s", err)
 	}
 	defer func(fname string) {
-		if _, err := os.Stat(fname); !os.IsNotExist(err) {
+		if _, localErr := os.Stat(fname); !os.IsNotExist(localErr) {
 			err = os.Remove(fname)
 		}
 	}(tmpfile.Name())


### PR DESCRIPTION
The code was intending to side-effect on the returned error but didn't
due to the local shadowing.

Cannot test this until/without refactoring to have mockable file system operations.

Impact of bug:

If the an update fails later *and* we fail to remove the temporary
file during cleanup, we would report the original failure rather than
the failure to remove the temporary file (it could be argued this is
actually a good thing).

If an update otherwise succeeds and the deletion of the temporary file
fails, we would silently ignore that error rather than reporting it to
the user or calling process. The result is a left-over encrypted
temporary file.