### PR TITLE
Add defensive os.Exit(1)

### DIFF
--- a/saltybox.go
+++ b/saltybox.go
@@ -129,6 +129,10 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
+		// We do not actually expect to get here because urfave
+		// should be exiting for us. But if we do, let's make sure we
+		// log and exit with an appropriate code.
 		log.Fatal(err)
+		os.Exit(1)
 	}
 }

--- a/tests/cmdline.sh
+++ b/tests/cmdline.sh
@@ -23,3 +23,9 @@ echo "updated data" > "${tmpdir}/updated_data.txt"
 echo -n test | ./saltybox --passphrase-stdin update -i "${tmpdir}/updated_data.txt" -o "${tmpdir}/hello-encrypted2.txt.salty"
 echo -n test | ./saltybox --passphrase-stdin decrypt -i "${tmpdir}/hello-encrypted2.txt.salty" -o "${tmpdir}/updated_data-decrypted.txt"
 diff "${tmpdir}/updated_data.txt" "${tmpdir}/updated_data-decrypted.txt"
+
+# ensure we exit with non-zero in case of errors
+if ./saltybox --passphrase-stdin decrypt -i testdata/nonexistent.salty -o foo 2>/dev/null; then
+    echo "saltybox should have failed (decrypting non-existent file) but it succeeded" >&2
+    exit 1
+fi


### PR DESCRIPTION
There is no actual bug because urfave exits for us. However this was entirely non-obvious at first glance, and we lacked test coverage.