### PR TITLE
Remove redundant exit call

### DIFF
--- a/saltybox.go
+++ b/saltybox.go
@@ -137,6 +137,5 @@ func main() {
 		// should be exiting for us. But if we do, let's make sure we
 		// log and exit with an appropriate code.
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
- log.Fatal() already exits with a non-zero status so remove the extra `os.Exit(1)` call in `main`

## Testing
- `go build -o saltybox` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
- `bash tests/cmdline.sh` *(fails: `./saltybox: No such file or directory`)*