### PR TITLE
Fix docstring typos.

### DIFF
--- a/varmor/varmor.go
+++ b/varmor/varmor.go
@@ -25,12 +25,12 @@ func Wrap(body []byte) string {
 
 // Unwrap an armored string.
 //
-// Errors conditions include:
+// Error conditions include:
 //
 //   - The input is provably truncated.
 //   - Base64 decoding failure.
-//   - Input indicates a future version of of the format that we do not support.
-//   - Input does not appear to be the the result of Wrap().
+//   - Input indicates a future version of the format that we do not support.
+//   - Input does not appear to be the result of Wrap().
 func Unwrap(varmoredBody string) ([]byte, error) {
 	if len(varmoredBody) < len(v1Magic) {
 		return nil, errors.New("input size smaller than magic marker; likely truncated")


### PR DESCRIPTION
## Summary
- correct typos in `varmor.go` documentation comments

## Testing
- `go test ./...` *(fails: no route to host)*