### PR TITLE
Inspect project for bugs and suggest fixes

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -105,6 +105,9 @@ func Update(plainfile string, cryptfile string, pr preader.PassphraseReader) (er
 	// and rename). This guarantees that the resulting file will either be the old file or the new
 	// file, but never corrupt (assuming a correctly functioning filesystem I/O stack).
 	cryptDir, _ := filepath.Split(cryptfile)
+	if cryptDir == "" {
+		cryptDir = "."
+	}
 
 	tmpfile, err := os.CreateTemp(cryptDir, "saltybox-update-tmp")
 	if err != nil {
@@ -112,11 +115,11 @@ func Update(plainfile string, cryptfile string, pr preader.PassphraseReader) (er
 	}
 	defer func(fname string) {
 		if _, localErr := os.Stat(fname); !os.IsNotExist(localErr) {
-			err = os.Remove(fname)
+			_ = os.Remove(fname)
 		}
 	}(tmpfile.Name())
 	defer func(tmpfile *os.File) {
-		err = tmpfile.Close()
+		_ = tmpfile.Close()
 	}(tmpfile)
 
 	err = Encrypt(plainfile, tmpfile.Name(), cachingPreader)
@@ -132,7 +135,7 @@ func Update(plainfile string, cryptfile string, pr preader.PassphraseReader) (er
 		return fmt.Errorf("failed to re-open tempfile after encryption: %w", err)
 	}
 	defer func(f *os.File) {
-		err = f.Close()
+		_ = f.Close()
 	}(reopenedTmpFile)
 
 	err = reopenedTmpFile.Sync()

--- a/preader/preader.go
+++ b/preader/preader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"golang.org/x/term"
 )
@@ -90,5 +91,5 @@ func (r *readerPassphraseReader) ReadPassphrase() (string, error) {
 		return "", fmt.Errorf("error reading passphrase: %w", err)
 	}
 
-	return string(data), nil
+	return strings.TrimRight(string(data), "\r\n"), nil
 }

--- a/saltybox.go
+++ b/saltybox.go
@@ -102,7 +102,7 @@ func main() {
 
    If the output file does not already exist, or if it does not appear to be a valid saltybox file, the operation will fail.
 
-   If the passphrase provided by the user does unlock the existing file, the operation will fail. By using the update command,
+   If the passphrase provided by the user does not unlock the existing file, the operation will fail. By using the update command,
    the user thereby avoids accidentally changing the passphrase as would be possible if using the encrypt command and separately
    replacing the target file.`,
 				Flags: []cli.Flag{

--- a/secretcrypt/secretcrypt.go
+++ b/secretcrypt/secretcrypt.go
@@ -139,7 +139,9 @@ func Decrypt(passphrase string, crypttext []byte) ([]byte, error) {
 	if sealedBoxLen > int64(maxInt) {
 		return nil, errors.New("sealed box length exceeds max int")
 	}
-	if sealedBoxLen > int64(len(crypttext)) {
+	// Ensure the declared sealed box length does not exceed the remaining bytes in the input
+	remaining := cryptReader.Len()
+	if sealedBoxLen > int64(remaining) {
 		return nil, errors.New("truncated or corrupt input; claimed length greater than available input")
 	}
 


### PR DESCRIPTION
Addresses several bugs: improves error handling in `commands.Update`, trims stdin passphrases, corrects a CLI description, and hardens decryption length validation.

The `commands.Update` changes prevent deferred cleanup errors from masking primary function errors and ensure temp files are correctly placed. The `secretcrypt.Decrypt` change improves robustness against malformed input by validating the declared sealed box length against the *remaining* available bytes, preventing potential panics or incorrect decryption.

---
<a href="https://cursor.com/background-agent?bcId=bc-323d4c7f-98a1-411d-a44e-eefaed625a7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-323d4c7f-98a1-411d-a44e-eefaed625a7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

