### PR TITLE
fix: sync output directory after writes

### DIFF
--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -125,13 +125,34 @@ fn update_paths_conflict(plain_path: &Path, crypt_path: &Path) -> bool {
         )
 }
 
-/// Write file with secure permissions (0o600 on Unix)
+/// Replaces a file through a private same-directory temporary file.
+///
+/// On Unix, successful writes sync both the tempfile contents and the containing
+/// directory so the replacement survives crashes that happen after rename
+/// returns. The resulting file mode is `0600`.
 fn write_file_secure(path: &Path, contents: &[u8]) -> Result<()> {
     let output_dir = path.parent().ok_or_else(|| {
         SaltyboxError::with_kind(
             ErrorCategory::User,
             ErrorKind::Io,
             "output path has no parent directory",
+        )
+    })?;
+    let output_dir = if output_dir.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        output_dir
+    };
+    #[cfg(unix)]
+    let output_dir_file = fs::File::open(output_dir).map_err(|e| {
+        SaltyboxError::with_kind_and_source(
+            ErrorCategory::Internal,
+            ErrorKind::Io,
+            format!(
+                "failed to open output directory for syncing after writing {}",
+                path.display()
+            ),
+            e,
         )
     })?;
     let mut temp_file = tempfile::Builder::new()
@@ -203,6 +224,19 @@ fn write_file_secure(path: &Path, contents: &[u8]) -> Result<()> {
             e,
         )
     })?;
+    #[cfg(unix)]
+    {
+        // The file sync above covers the bytes. The directory sync makes the
+        // rename itself durable so a crash cannot lose the new directory entry.
+        output_dir_file.sync_all().map_err(|e| {
+            SaltyboxError::with_kind_and_source(
+                ErrorCategory::Internal,
+                ErrorKind::Io,
+                format!("failed to sync directory after writing {}", path.display()),
+                e,
+            )
+        })?;
+    }
     Ok(())
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -125,6 +125,63 @@ fn test_encrypt_decrypt_roundtrip() {
     assert_eq!(original, decrypted);
 }
 
+/// Exercises output paths such as `out.salty` that have no directory component.
+///
+/// `Path::parent()` reports these as having an empty parent path. The CLI still
+/// needs to treat them as files in the child process's current directory.
+#[test]
+fn test_output_path_without_directory_component_roundtrip() {
+    let temp_dir = TempDir::new().unwrap();
+    let plaintext = temp_dir.path().join("plain.txt");
+
+    fs::write(&plaintext, "bare relative output").unwrap();
+
+    let mut child = Command::new(saltybox_bin())
+        .arg("--passphrase-stdin")
+        .args([
+            "encrypt",
+            "-i",
+            plaintext.to_str().unwrap(),
+            "-o",
+            "out.salty",
+        ])
+        .current_dir(temp_dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.as_mut().unwrap().write_all(b"test").unwrap();
+    let result = child.wait_with_output().unwrap();
+    assert!(
+        result.status.success(),
+        "encrypt failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let mut child = Command::new(saltybox_bin())
+        .arg("--passphrase-stdin")
+        .args(["decrypt", "-i", "out.salty", "-o", "decrypted.txt"])
+        .current_dir(temp_dir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.as_mut().unwrap().write_all(b"test").unwrap();
+    let result = child.wait_with_output().unwrap();
+    assert!(
+        result.status.success(),
+        "decrypt failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    assert_eq!(
+        fs::read_to_string(temp_dir.path().join("decrypted.txt")).unwrap(),
+        "bare relative output"
+    );
+}
+
 #[test]
 fn test_passphrase_stdin_preserves_trailing_newline() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
This makes a successful output replacement durable on Unix by syncing the containing directory after the tempfile has been persisted. Syncing the file covers the bytes, but not necessarily the directory entry created by the rename.

This does make Unix writes depend on being able to open the output directory for syncing. That is the right tradeoff for the existing atomic/durable-write contract.

changelog: include
