### PR TITLE
chore: release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-05-31
+
+### Changed
+
+- Sync output directory after writes (#185)
+
 ## [3.2.1] - 2026-04-26
 
 ### Changed
@@ -23,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.0.0] - 2017-12-02
 
+[3.3.0]: https://github.com/scode/saltybox/compare/v3.2.1..v3.3.0
 [3.2.1]: https://github.com/scode/saltybox/compare/v3.2.0..v3.2.1
 [3.2.0]: https://github.com/scode/saltybox/compare/v3.1.0..v3.2.0
 [1.0.0]: https://github.com/scode/saltybox/tree/v1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "saltybox"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saltybox"
-version = "3.2.1"
+version = "3.3.0"
 authors = ["saltybox contributors"]
 default-run = "saltybox"
 edition = "2024"


### PR DESCRIPTION
Prepare the 3.3.0 release after the durable output-write fix landed on main.

changelog: skip
