### PR TITLE
fix: zeroize plaintext buffers after use

### DIFF
--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -10,6 +10,7 @@ use crate::varmor;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
+use zeroize::Zeroizing;
 
 const TEMPFILE_PREFIX: &str = ".saltybox-";
 const TEMPFILE_SUFFIX: &str = ".tmp";
@@ -26,7 +27,7 @@ pub fn encrypt_file(
     output_path: &Path,
     passphrase_reader: &mut dyn PassphraseReader,
 ) -> Result<()> {
-    let plaintext = fs::read(input_path).map_err(|e| read_error(input_path, e))?;
+    let plaintext = Zeroizing::new(fs::read(input_path).map_err(|e| read_error(input_path, e))?);
     let passphrase = passphrase_reader.read_passphrase()?;
     let ciphertext = secretcrypt::encrypt(&passphrase, &plaintext)
         .map_err(|e| e.with_context("encryption failed"))?;
@@ -109,7 +110,8 @@ pub fn update_file(
     secretcrypt::decrypt(&passphrase, &ciphertext)
         .map_err(|e| e.with_context("failed to decrypt"))?;
 
-    let new_plaintext = fs::read(plain_path).map_err(|e| read_error(plain_path, e))?;
+    let new_plaintext =
+        Zeroizing::new(fs::read(plain_path).map_err(|e| read_error(plain_path, e))?);
     let new_ciphertext = secretcrypt::encrypt(&passphrase, &new_plaintext)
         .map_err(|e| e.with_context("failed to encrypt"))?;
     let new_armored = varmor::wrap(&new_ciphertext);

--- a/src/secretcrypt.rs
+++ b/src/secretcrypt.rs
@@ -127,7 +127,11 @@ pub fn encrypt_deterministic(
 }
 
 /// Decrypt ciphertext with a passphrase
-pub fn decrypt(passphrase: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
+///
+/// The plaintext is returned in a `Zeroizing` buffer so it is wiped from
+/// memory on drop, matching the treatment of the passphrase and derived key
+/// (the plaintext is at least as sensitive as either).
+pub fn decrypt(passphrase: &[u8], ciphertext: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
     let mut pos = 0;
 
     if ciphertext.len() < pos + SALT_LEN {
@@ -224,7 +228,7 @@ pub fn decrypt(passphrase: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
         )
     })?;
 
-    Ok(plaintext)
+    Ok(Zeroizing::new(plaintext))
 }
 
 #[cfg(test)]
@@ -287,8 +291,8 @@ mod tests {
             &first[SALT_LEN..SALT_LEN + NONCE_LEN],
             &second[SALT_LEN..SALT_LEN + NONCE_LEN]
         );
-        assert_eq!(decrypt(passphrase, &first).unwrap(), plaintext);
-        assert_eq!(decrypt(passphrase, &second).unwrap(), plaintext);
+        assert_eq!(*decrypt(passphrase, &first).unwrap(), plaintext);
+        assert_eq!(*decrypt(passphrase, &second).unwrap(), plaintext);
     }
 
     #[test]
@@ -418,7 +422,7 @@ mod tests {
         let ciphertext = encrypt(passphrase, &plaintext).unwrap();
         let decrypted = decrypt(passphrase, &ciphertext).unwrap();
 
-        assert_eq!(plaintext, decrypted);
+        assert_eq!(plaintext, *decrypted);
     }
 
     #[test]
@@ -429,7 +433,7 @@ mod tests {
         let ciphertext = encrypt(passphrase, &plaintext).unwrap();
         let decrypted = decrypt(passphrase, &ciphertext).unwrap();
 
-        assert_eq!(plaintext, decrypted);
+        assert_eq!(plaintext, *decrypted);
     }
 
     #[test]
@@ -440,7 +444,7 @@ mod tests {
         let ciphertext = encrypt(passphrase, &plaintext).unwrap();
         let decrypted = decrypt(passphrase, &ciphertext).unwrap();
 
-        assert_eq!(plaintext, decrypted);
+        assert_eq!(plaintext, *decrypted);
     }
 
     #[test]
@@ -451,7 +455,7 @@ mod tests {
         let ciphertext = encrypt(passphrase, &plaintext).unwrap();
         let decrypted = decrypt(passphrase, &ciphertext).unwrap();
 
-        assert_eq!(plaintext, decrypted);
+        assert_eq!(plaintext, *decrypted);
     }
 
     #[test]

--- a/tests/golden_vectors.rs
+++ b/tests/golden_vectors.rs
@@ -134,7 +134,7 @@ fn run_golden_vector_tests(indices: Option<&[usize]>) {
             }
         };
 
-        if decrypted != expected_plaintext {
+        if *decrypted != expected_plaintext {
             eprintln!("Vector {}: FAILED - plaintext mismatch", i);
             eprintln!("  Comment: {}", vector.comment);
             eprintln!("  Expected length: {}", expected_plaintext.len());


### PR DESCRIPTION
The passphrase and derived key were already Zeroizing, but the plaintext —
at least as sensitive as either — was a plain Vec<u8>. decrypt now returns
Zeroizing<Vec<u8>> and the plaintext buffers read from disk in encrypt/update
are wrapped the same way, so plaintext is wiped from memory on drop across
the board. This is hardening for the memory-disclosure case (swap, core
dumps, reused allocations), not a change in on-disk behavior.

changelog: include
