### PR TITLE
ci: restrict CI workflow token to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
       - master
       - develop
 
+# CI only needs to read the repo. Without this, third-party actions run with
+# whatever the repository default GITHUB_TOKEN grants.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
ci.yml had no top-level permissions block, so all jobs — including the
third-party setup-rust-toolchain and dprint actions — ran with the
repository's default GITHUB_TOKEN grants. CI only needs to read the repo.
The other workflows already scope their tokens or use only first-party
actions.

changelog: skip
