### PR TITLE
fix: stop printing underlying error text twice

### DIFF
--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -53,7 +53,7 @@ impl PassphraseReader for ReaderPassphraseReader {
             SaltyboxError::with_kind_and_source(
                 ErrorCategory::Internal,
                 ErrorKind::Io,
-                format!("error reading passphrase: {}", e),
+                "error reading passphrase",
                 e,
             )
         })?;
@@ -90,7 +90,7 @@ impl PassphraseReader for TerminalPassphraseReader {
                 SaltyboxError::with_kind_and_source(
                     ErrorCategory::Internal,
                     ErrorKind::Io,
-                    format!("failed to write prompt: {}", e),
+                    "failed to write prompt",
                     e,
                 )
             })?;
@@ -98,7 +98,7 @@ impl PassphraseReader for TerminalPassphraseReader {
             SaltyboxError::with_kind_and_source(
                 ErrorCategory::Internal,
                 ErrorKind::Io,
-                format!("failed to flush prompt: {}", e),
+                "failed to flush prompt",
                 e,
             )
         })?;
@@ -109,7 +109,7 @@ impl PassphraseReader for TerminalPassphraseReader {
             SaltyboxError::with_kind_and_source(
                 ErrorCategory::Internal,
                 ErrorKind::PassphraseUnavailable,
-                format!("failure reading passphrase: {}", e),
+                "failure reading passphrase",
                 e,
             )
         })?;

--- a/src/varmor.rs
+++ b/src/varmor.rs
@@ -35,7 +35,7 @@ pub fn unwrap(armored: &str) -> Result<Vec<u8>> {
             SaltyboxError::with_kind_and_source(
                 ErrorCategory::User,
                 ErrorKind::ArmoringDecode,
-                format!("base64 decoding failed: {}", e),
+                "base64 decoding failed",
                 e,
             )
         })?;
@@ -180,6 +180,9 @@ mod tests {
         let result = unwrap("saltybox1:bad$$");
         let err = result.expect_err("expected base64 decode error");
         assert_eq!(err.kind, Some(ErrorKind::ArmoringDecode));
+        // The message no longer embeds the decode failure text, so the source
+        // must stay attached for the CLI's "caused by" chain to surface it.
+        assert!(std::error::Error::source(&err).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Five error sites embedded the source error in the message via `format!` while also attaching it as `#[source]`, so `report_error` printed the underlying text both in the top-line message and again as `caused by:`. The dominant pattern elsewhere attaches the source without embedding.

changelog: include
