### PR TITLE
refactor: apply idiomaticity and simplification review feedback

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -97,11 +97,11 @@ impl SaltyboxError {
 
     /// Wraps the current error with a higher-level message while preserving the original as source.
     pub fn with_context(self, msg: impl Into<String>) -> Self {
-        let category = self.category;
-        let kind = self.kind;
+        // Field initializers run in source order, so the Copy fields are read
+        // before `self` moves into `source`.
         Self {
-            category,
-            kind,
+            category: self.category,
+            kind: self.kind,
             source: Some(Box::new(self)),
             msg: msg.into(),
         }

--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -31,7 +31,7 @@ impl ConstantPassphraseReader {
 #[cfg(test)]
 impl PassphraseReader for ConstantPassphraseReader {
     fn read_passphrase(&mut self) -> Result<Zeroizing<Vec<u8>>> {
-        Ok(Zeroizing::new((*self.passphrase).clone()))
+        Ok(self.passphrase.clone())
     }
 }
 
@@ -61,14 +61,7 @@ impl PassphraseReader for ReaderPassphraseReader {
     }
 }
 /// Reads passphrase from terminal with no echo
-#[derive(Default)]
 pub struct TerminalPassphraseReader;
-
-impl TerminalPassphraseReader {
-    pub fn new() -> Self {
-        Self
-    }
-}
 
 impl PassphraseReader for TerminalPassphraseReader {
     /// Read passphrase from terminal.
@@ -136,7 +129,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_terminal_reader_interactive() {
-        let mut reader = TerminalPassphraseReader::new();
+        let mut reader = TerminalPassphraseReader;
         println!("\nPlease enter a test passphrase:");
         let passphrase = reader.read_passphrase().unwrap();
         println!("You entered: {}", String::from_utf8_lossy(&passphrase));

--- a/src/secretcrypt.rs
+++ b/src/secretcrypt.rs
@@ -16,7 +16,6 @@ use crypto_secretbox::{Nonce, XSalsa20Poly1305};
 use rand::TryRng;
 use rand::rngs::SysRng;
 use scrypt::{Params, scrypt};
-use std::mem::{size_of, size_of_val};
 use zeroize::Zeroizing;
 
 /// Length of salt in bytes

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -26,18 +26,15 @@ fn run_saltybox_with_passphrase(
         .stderr(Stdio::piped())
         .spawn()?;
 
-    let stdin_write_error = {
-        let stdin = child.stdin.as_mut().expect("failed to open stdin");
-        if let Err(err) = stdin.write_all(passphrase.as_bytes()) {
-            if err.kind() != io::ErrorKind::BrokenPipe {
-                Some(err)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    };
+    // A broken pipe means the child exited before reading all of stdin; the
+    // exit status reports that failure more usefully than the write error.
+    let stdin_write_error = child
+        .stdin
+        .as_mut()
+        .expect("failed to open stdin")
+        .write_all(passphrase.as_bytes())
+        .err()
+        .filter(|err| err.kind() != io::ErrorKind::BrokenPipe);
     drop(child.stdin.take());
 
     let output = child.wait_with_output();


### PR DESCRIPTION
Small idiomaticity and simplification cleanups: clone `Zeroizing` directly instead of unwrapping and re-wrapping the inner vec, drop `std::mem::size_of` imports that are in the prelude since Rust 1.80, let `with_context` read its `Copy` fields directly in the struct literal, remove the unused `TerminalPassphraseReader::new`/`Default`, and collapse a nested if/else around the test-helper stdin write into `.err().filter(...)`.

Deliberately keeps `temp_file.flush()` before `sync_all()` in file_ops: std documents `File::flush` as only *currently* a no-op and reserves the right to change it, and flush-before-sync is the ordering that is correct by the `Write` contract rather than by current implementation — which matters in the crash-durability path.

changelog: skip
