### PR TITLE
chore: release 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-06-11
+
+### Fixed
+
+- Reject hardlinked input/output paths in update (#192)
+- Stop misdiagnosing short non-saltybox input as truncated (#193)
+- Classify missing output directory as a user error (#194)
+- Zeroize plaintext buffers after use (#195)
+- Stop printing underlying error text twice (#202)
+
 ## [3.3.0] - 2026-05-31
 
-### Changed
+### Fixed
 
 - Sync output directory after writes (#185)
 
@@ -19,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [3.2.0] - 2026-03-05
 
-### Changed
+### Added
 
 - Setup homebrew based distribution (#154)
 
@@ -29,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.0.0] - 2017-12-02
 
+[3.3.1]: https://github.com/scode/saltybox/compare/v3.3.0..v3.3.1
 [3.3.0]: https://github.com/scode/saltybox/compare/v3.2.1..v3.3.0
 [3.2.1]: https://github.com/scode/saltybox/compare/v3.2.0..v3.2.1
 [3.2.0]: https://github.com/scode/saltybox/compare/v3.1.0..v3.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "saltybox"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saltybox"
-version = "3.3.0"
+version = "3.3.1"
 authors = ["saltybox contributors"]
 default-run = "saltybox"
 edition = "2024"

--- a/cliff.toml
+++ b/cliff.toml
@@ -65,14 +65,19 @@ commit_parsers = [
   { message = "(?i)\\bchangelog\\s*:\\s*skip\\b", skip = true },
   { body = "(?i)\\bchangelog\\s*:\\s*skip\\b", skip = true },
   { footer = "(?i)\\bchangelog\\s*:\\s*skip\\b", skip = true },
-  { message = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
-  { body = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
-  { footer = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
   # Conventional Commit types included in changelog (user-visible changes).
+  # These must run before the "changelog: include" override below: PR bodies
+  # always contain "changelog: include" (CI-enforced), and if the override ran
+  # first it would force every commit into "Changed" regardless of type.
   { message = "^feat(\\([^\\)]+\\))?!?:", group = "Added" },
   { message = "^fix(\\([^\\)]+\\))?!?:", group = "Fixed" },
   { message = "^perf(\\([^\\)]+\\))?!?:", group = "Performance" },
   { message = "^revert(\\([^\\)]+\\))?!?:", group = "Reverted" },
+  # "changelog: include" rescues commit types that would otherwise be skipped
+  # (e.g. a refactor worth calling out); they land under "Changed".
+  { message = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
+  { body = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
+  { footer = "(?i)\\bchangelog\\s*:\\s*include\\b", group = "Changed" },
   # Conventional Commit types excluded from changelog (non-user-visible).
   { message = "^(docs|doc|refactor|style|test|chore|ci)(\\([^\\)]+\\))?!?:", skip = true },
 ]


### PR DESCRIPTION
Also reorders cliff.toml commit parsers: the CI-enforced include tag in PR bodies was matching before the type-based parsers, forcing every changelog entry into the Changed section. Fix commits now land under Fixed.

changelog: skip