### PR TITLE
docs: add saltybox2 transition plan lore

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -7,7 +7,8 @@
   },
   "toml": {},
   "excludes": [
-    "**/*-lock.json"
+    "**/*-lock.json",
+    "lore/**"
   ],
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.0.wasm",

--- a/lore/2026-07-01-saltybox2.md
+++ b/lore/2026-07-01-saltybox2.md
@@ -1,0 +1,345 @@
+# saltybox2: crypto modernization transition plan
+
+NOTE: This is a working plan, not a specification. User-visible behavior is
+specified in `SPEC.md` (created by step 1 below). If this document and
+`SPEC.md` ever disagree about behavior, `SPEC.md` wins. This document exists
+to sequence the work, record the requirements and decisions that shaped it,
+and provide ready-to-use goals for `/goal` in codex/claude.
+
+Context: saltybox's cryptographic parameters date back to the original Go
+implementation — scrypt at N=2^15 (32 MiB) with an 8-byte salt, and
+XSalsa20-Poly1305 for the AEAD. None of it is broken, but all of it is dated:
+the salt is below the modern 128-bit floor, the scrypt cost sits at the 2009
+"interactive login" tier rather than something appropriate for files at rest,
+and ecosystem scrutiny has moved from Salsa20 to ChaCha20. The end state is a
+new `saltybox2` format using Argon2id and XChaCha20-Poly1305. The old format
+remains decryptable forever.
+
+## Requirements
+
+These are the requirements that shaped this plan, as stated at planning time:
+
+- Backwards compatibility with the old format is NOT dropped, including
+  maintaining test coverage for it.
+- The old code is mostly kept as-is. No complicated dual-format code paths
+  that accrete complexity: encryption is factored behind a trait (or
+  equivalent) so the old and new implementations sit side by side, with the
+  old one effectively unchanged to minimize the chance of bugs.
+- Refactor diffs are clean and contain zero functional changes, strictly
+  separated from diffs that introduce functional changes.
+- PRs land incrementally with new functionality turned off from the CLI's
+  perspective (except when enabled via an experimental environment variable
+  for testing), until a final PR flips the new behavior on. NOTE: this
+  applies to the write path; v2 *decryption* is deliberately enabled as soon
+  as it is wired (step 5) — see the decision below on unconditional decrypt.
+- The work is split into small reviewable PRs, each standing fully on its own
+  with comprehensive test coverage.
+- Every individual PR is first created, then reviewed with
+  `pre-pr-review-swarm` exactly once, then updated with the surviving
+  feedback.
+- The very first step creates `SPEC.md`, defining user-visible behavior in
+  specification form with no implementation details. Old behavior is not
+  bootstrapped into it wholesale; the spec is kept up to date as behavior is
+  added or changed. `AGENTS.md` enforces `SPEC.md` compliance except when a
+  change intentionally alters behavior (in which case the spec is updated in
+  the same change).
+- Every step of the plan is expressed as an achievable goal usable with
+  `/goal` in codex/claude.
+
+## Decisions settled during planning
+
+- The byte-level on-disk format is part of `SPEC.md`, not treated as an
+  implementation detail. Files must remain decryptable forever, possibly by
+  reimplementations, so the format is a user-visible contract.
+- `SPEC.md` starts as a skeleton. Areas get spec'd — including their current
+  v1 behavior — in the PR that touches them. Behavior never touched by this
+  project may remain unspecified indefinitely.
+- Post-flip, `update` always writes the current default format. Running
+  `update` on a v1 file upgrades it to v2; this is the intended migration
+  path.
+- Post-flip, v1 is decrypt-only. There is no flag or variable to write v1.
+  The v1 encryption code remains in the library solely so tests can keep
+  exercising both directions.
+- `AGENTS.md` becomes the canonical agent instruction file (absorbing the
+  current `CLAUDE.md` content plus the spec-compliance rule); `CLAUDE.md`
+  becomes a symlink to it.
+- The experimental gate is `SALTYBOX_EXPERIMENTAL_V2=1`, affecting the write
+  path only. It is deleted entirely at flip time. An environment variable
+  (rather than a flag, the usual preference for user-facing commands) is
+  deliberate: the gate is temporary, meant to be invisible in `--help`, and
+  scheduled for removal.
+- v2 decryption is enabled unconditionally as soon as it is implemented and
+  wired (accepting more inputs is harmless and means any experimentally
+  written file is readable by a released binary).
+- All branch and PR mechanics use the `jjstack` skill, as a strictly linear
+  stack: one commit, one bookmark, one PR per step, landed bottom-up.
+- The flip is `feat!` and releases as 4.0.0. Old binaries cannot read new
+  files; the major bump signals the one-way door.
+- v2 golden vectors are cross-verified against an independent implementation
+  (libsodium/PyNaCl + argon2-cffi), the same way v1 vectors were verified
+  against the Go implementation. The generator script is committed alongside
+  the vectors.
+- The zero-functional-change refactor is two PRs: a verbatim code move, then
+  the trait introduction. Each diff is trivially auditable on its own.
+
+## Target design
+
+This section records design intent. The normative version of all of this goes
+into `SPEC.md` as the corresponding steps land.
+
+### saltybox2 format
+
+Armor: `saltybox2:` followed by base64url without padding, same armor
+properties as v1 (no whitespace, shell- and URL-safe).
+
+Binary layout (the base64 payload):
+
+- salt: 16 bytes, random per file
+- m: u32 big-endian, Argon2id memory cost in KiB
+- t: u32 big-endian, Argon2id time cost (passes)
+- p: u32 big-endian, Argon2id parallelism (lanes)
+- nonce: 24 bytes, random per file
+- ciphertext plus 16-byte Poly1305 tag: everything to end of input (no length
+  field; the file is the container, and trailing data past the armor is
+  impossible by construction)
+
+Key derivation: Argon2id, version 0x13, 32-byte output. The Argon2 version
+and output length are fixed properties of the saltybox2 format, not header
+fields. Write defaults: m=262144 (256 MiB), t=3, p=1.
+
+Decrypt-side parameter validation, enforced before running the KDF so a
+hostile file cannot turn key derivation into a memory or CPU bomb:
+m <= 4194304 (4 GiB), t <= 64, p <= 8, plus the Argon2 floors (t >= 1,
+p >= 1, m >= 8*p). Out-of-range parameters are a format error, not an
+authentication failure. Parameters below the write defaults but within range
+decrypt normally; they only affect files the user chose to write that way.
+
+AEAD: XChaCha20-Poly1305. Associated data is the ASCII armor magic
+`saltybox2:` concatenated with the header bytes (salt, m, t, p, nonce), so a
+successful decrypt proves the entire envelope — including the version
+identifier — was untampered.
+
+Libraries: RustCrypto `argon2` and `chacha20poly1305` crates, replacing
+`scrypt` and `crypto_secretbox` on the write path (`scrypt` and
+`crypto_secretbox` stay as long as v1 decryption exists, i.e. forever). The
+`argon2` `parallel` feature is NOT enabled; with p=1 it buys nothing and
+pulls in rayon. The dev/test profile gets `opt-level = 3` for `argon2`,
+mirroring the existing scrypt override and for the same reason.
+
+### Deliberately out of scope
+
+Key-committing AEAD constructions (irrelevant for single-passphrase use),
+streaming or chunked encryption (whole-file-in-memory matches the tool's
+scope), post-quantum measures (256-bit symmetric is fine), and KDF
+autotuning (fixed write defaults are simpler; the params-in-header design
+means a future cost bump is a constant edit, not a format change).
+
+## Standard PR protocol
+
+Every step below is exactly one PR and follows this protocol. Goals reference
+it as "the Standard PR protocol in lore/2026-07-01-saltybox2.md".
+
+1. Implement the step as a single new commit on top of the stack, using the
+   `jjstack` skill for all branch/bookmark/PR mechanics. The stack stays
+   strictly linear.
+2. All checks pass locally: `cargo test`, `cargo clippy --all-targets`,
+   `cargo fmt --check`, `dprint check`.
+3. Create the PR via `jjstack`. The title follows Conventional Commits per
+   `AGENTS.md` (or `CLAUDE.md` before step 1 lands), with the type reflecting
+   user-visible behavior. The body contains exactly one of
+   `changelog: include` or `changelog: skip`.
+4. Immediately after creating the PR — before running any review or making
+   any further changes — tag the exact commit the PR was created with as
+   `eval/pre-pr-review-swarm/<slug>-initial`, where `<slug>` is the PR's
+   bookmark name without its `pr/` prefix, and push the tag to origin. These
+   tags publicly preserve each PR's pre-review state so the initial commits
+   can later serve as an eval corpus for `pre-pr-review-swarm` (comparing
+   what was first published against what survived review). jj does not
+   manage tags, so use plain git for this one operation:
+   `git tag eval/pre-pr-review-swarm/<slug>-initial <commit>` followed by
+   `git push origin refs/tags/eval/pre-pr-review-swarm/<slug>-initial`.
+   Never move or delete these tags afterwards.
+5. Run `pre-pr-review-swarm` exactly once.
+6. Apply the feedback that survives scrutiny — staying scoped to the step —
+   and update the PR via `jjstack`.
+7. Do not merge. Landing is the user's call.
+
+Additional rules that apply across all steps:
+
+- Any PR that changes user-visible behavior updates `SPEC.md` in the same PR
+  (`AGENTS.md` enforces this from step 1 onward).
+- Steps marked refactor-only must be verifiably zero-functional-change: the
+  golden vector tests and all existing tests pass, with edits to *existing*
+  tests limited to import/module paths. New tests covering newly introduced
+  structure (e.g. the dispatch layer) are expected and do not violate this.
+- Tests never mutate the environment of the test process. Environment
+  variable behavior is tested by spawning the built binary with the variable
+  set on the child process only (the existing CLI integration tests already
+  spawn the binary).
+
+## Steps
+
+### Step 1: SPEC.md skeleton, AGENTS.md enforcement
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 1 following its Standard
+PR protocol. Create SPEC.md at the repo root: a preamble stating that it
+specifies user-visible behavior (CLI behavior and on-disk formats) in
+specification form with no implementation details, that behavior not yet
+covered is existing-but-unspecified and gets spec'd when a change touches it,
+and skeleton section structure for commands and file formats. Create
+AGENTS.md as the canonical agent instruction file: absorb the full current
+content of CLAUDE.md, and add a rule that changes must comply with SPEC.md —
+any change to user-visible behavior must update SPEC.md in the same change,
+and SPEC.md governs except when a task intentionally changes behavior.
+Replace CLAUDE.md with a symlink to AGENTS.md. (The lore/ directory itself,
+including this plan, and the lore/** dprint exclusion landed in a separate
+docs PR before this step; lore documents are frozen historical artifacts per
+lore/AGENTS.md, which is why the formatter must never touch them.) Title
+type: docs. changelog: skip. Acceptance: SPEC.md and AGENTS.md exist as
+described, CLAUDE.md is a symlink, no code changes.
+```
+
+### Step 2: verbatim move of v1 crypto (refactor, zero functional change)
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 2 following its Standard
+PR protocol. Move the existing scrypt + XSalsa20-Poly1305 implementation in
+src/secretcrypt.rs to a v1-named module (e.g. src/secretcrypt_v1.rs; exact
+naming at your discretion). The move is verbatim: no logic, signature,
+comment, or error-message changes — only module declarations and import
+paths change, in src and in tests. Title type: refactor. changelog: skip.
+Acceptance: the diff is auditable as a pure move, all existing tests
+including golden vectors pass with edits limited to import/module paths, and
+SPEC.md needs no update because behavior is unchanged.
+```
+
+### Step 3: format engine trait and version dispatch (refactor, zero functional change)
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 3 following its Standard
+PR protocol. Introduce a trait (or equivalent) representing a saltybox
+format engine — armor magic plus encrypt/decrypt of the armored payload —
+and route the CLI's encrypt/decrypt/update paths through the dispatch
+layer: read-side dispatch is keyed on the armor prefix, while the write side
+selects a single designated default write engine (there is no prefix to
+dispatch on when encrypting; this default is what steps 6 and 7 later
+switch). The v1 engine from step 2 is the only registered implementation
+and the default write engine. The v1 module body remains unchanged; adaptation
+happens in the new dispatch layer. Design the trait so an engine can
+incorporate its armor magic into what it authenticates, since the v2 engine
+will use the magic as AEAD associated data. Preserve the existing error
+diagnostics exactly (truncated-magic, unsupported-future-version, and
+unrecognized-input distinctions in varmor). Title type: refactor.
+changelog: skip. Acceptance: zero functional change — all existing tests
+including golden vectors and CLI integration tests pass, error messages are
+byte-identical, and SPEC.md needs no update.
+```
+
+### Step 4: v2 engine, unwired (no user-visible change)
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 4 following its Standard
+PR protocol. Implement the saltybox2 engine exactly as described in the
+plan's "Target design" section: Argon2id (RustCrypto argon2 crate, parallel
+feature off) with params-in-header and decrypt-side caps, XChaCha20-Poly1305
+(RustCrypto chacha20poly1305 crate) with the armor magic and header as AAD,
+16-byte salt, no length field. Add the dev/test profile opt-level=3 override
+for argon2 mirroring the scrypt one. Do NOT register the engine in the
+dispatch layer and do NOT touch the CLI: this PR has no user-visible change.
+Provide a deterministic-encryption test hook (fixed salt, nonce, and params)
+documented as test-only, mirroring v1's encrypt_deterministic. Add thorough
+unit tests: round-trips, wrong passphrase, tampered ciphertext, tampered
+header bytes, truncation at every field boundary, and parameter validation.
+For header tampering, note that a flipped parameter byte can land out of the
+validation range: assert the authentication-failure error when the tampered
+value remains in range (e.g. t: 3 -> 2), and the parameter-range format
+error otherwise — every flip must fail, with the correct diagnosis.
+Parameter caps are exercised via rejection only (cap+1 fails before any KDF
+work runs); do NOT write a test that runs Argon2id at the caps themselves (m
+at its cap is a 4 GiB allocation). In-range acceptance is covered by the
+small-parameter tests. Put saltybox2 golden vectors in a new file (e.g.
+testdata/golden-vectors-v2.json) rather than extending
+testdata/golden-vectors.json, whose schema is v1-specific and whose harness
+must remain untouched. Generate the vectors with an independent
+implementation (e.g. Python with argon2-cffi's hash_secret_raw and PyNaCl's
+XChaCha20-Poly1305, which PyNaCl exposes only via
+nacl.bindings.crypto_aead_xchacha20poly1305_ietf_*, not a high-level class);
+commit the generator script under testdata/ and note it in testdata/README. Use small-but-valid Argon2 params (e.g. m=8192, t=3,
+p=1) in golden vectors and most tests to keep the suite fast; include one
+round-trip test at the write defaults, marked #[ignore] only if it exceeds a
+few seconds. Title type: chore. changelog: skip. Acceptance: engine complete
+and fully tested, cross-verified vectors committed, CLI behavior and SPEC.md
+unchanged.
+```
+
+### Step 5: accept saltybox2 on the read path (user-visible)
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 5 following its Standard
+PR protocol. Register the v2 engine in the version dispatch so decrypt — and
+update's validation read — accept saltybox2 input unconditionally. Inputs
+claiming saltybox versions above 2 now get the unsupported-future-version
+diagnostic, and input that is a proper prefix of ANY supported magic
+(including bare "saltybox2", which today gets the future-version error) now
+gets the likely-truncated diagnostic; the existing varmor test pinning
+"saltybox2" as future-version changes accordingly, and this taxonomy is part
+of the decrypt spec below. Update SPEC.md in this PR: specify the saltybox1 and saltybox2
+armored and binary formats byte-for-byte (per the plan's Target design,
+including Argon2 parameter validation ranges and their distinct error
+category), and specify decrypt's user-visible behavior — accepted formats
+and the error taxonomy distinguishing truncated, unrecognized,
+future-version, malformed, and authentication-failure inputs. Add CLI
+integration tests decrypting saltybox2 fixtures derived from the step 4
+golden vectors, plus spec-mandated error cases. Title type: feat.
+changelog: include. Acceptance: a released binary built from this PR
+decrypts both formats, encrypt/update still write only v1, SPEC.md fully
+covers both formats and decrypt behavior.
+```
+
+### Step 6: experimental v2 write path behind SALTYBOX_EXPERIMENTAL_V2
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 6 following its Standard
+PR protocol. When the environment variable SALTYBOX_EXPERIMENTAL_V2 is set
+to exactly "1", encrypt and update write saltybox2 with the write-default
+parameters (m=262144, t=3, p=1); when unset, behavior is unchanged (v1);
+when set to any other value, fail with a clear error rather than guessing.
+The variable is consulted only by commands that write (encrypt and update);
+decrypt ignores it entirely, including invalid values. Update SPEC.md in
+this PR: spec the encrypt and update commands' baseline behavior (this is
+the PR that touches them) — by default they write saltybox1; the output
+format is a function of the gate alone, never of the input format, so
+update on a saltybox2 file with the gate unset writes saltybox1 (spell this
+downgrade out explicitly) — and document the variable itself, explicitly
+marked experimental and scheduled for removal at the format flip. Add CLI
+integration tests covering all three variable states by spawning the built
+binary with the variable set on the child process only — never mutate the
+test process environment. Include a round-trip integration test proving a
+file written under the variable decrypts without it. Title type: feat.
+changelog: skip (experimental; announced at the flip instead). Acceptance:
+default behavior is byte-identical to step 5, the gated path is fully
+tested, SPEC.md documents the gate.
+```
+
+### Step 7: flip — saltybox2 becomes the write format
+
+```
+Read lore/2026-07-01-saltybox2.md and execute step 7 following its Standard
+PR protocol. Make encrypt and update write saltybox2 unconditionally and
+delete SALTYBOX_EXPERIMENTAL_V2 entirely (the variable is no longer read).
+Remove v1 from the CLI write path; keep the v1 encryption code in the
+library so tests continue to cover v1 in both directions, and keep all v1
+golden vector and decrypt coverage. Update SPEC.md in this PR: encrypt and
+update write saltybox2 (update thereby upgrades v1 files — spell out that
+this is the migration path), v1 is decrypt-only, and the experimental
+variable section is removed. Update README.md and the Cargo.toml description
+to stop describing the tool as scrypt/NaCl-secretbox-based, describe both
+formats accurately, and note that files written by this version cannot be
+read by pre-4.0 binaries. Title type: feat! (this releases as 4.0.0).
+changelog: include. Acceptance: fresh encrypts produce saltybox2, v1 files
+decrypt and upgrade via update, no reference to the experimental variable
+remains outside lore/ and CHANGELOG.md history (lore documents are frozen
+and must NOT be edited to scrub it), SPEC.md and README match actual
+behavior.
+```

--- a/lore/AGENTS.md
+++ b/lore/AGENTS.md
@@ -1,0 +1,14 @@
+# The lore/ directory
+
+Files in this directory are historical "lore": plans, design notes, and
+similar artifacts capturing thinking at a point in time. Once committed they
+are frozen. Do not update, maintain, or "fix" them as the codebase evolves —
+they are expected to drift out of date, and that drift is part of the record.
+
+Nothing in lore/ is ever authoritative for the current codebase. These
+documents exist purely for historical archeology around intent and
+decisions; the codebase (code, tests, SPEC.md, and the other top-level docs)
+stands on its own and must be understandable without reading any of this.
+Never treat a claim in a lore document as true of the code as it is now —
+verify against the code and SPEC.md instead. If a lore document and current
+reality disagree, reality wins; do not edit the document to match.

--- a/lore/CLAUDE.md
+++ b/lore/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add plan for modernizing cryptography and a transition to saltybox v2 format.

changelog: skip
