### PR TITLE
feat: accept saltybox2 format when decrypting

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,8 +10,115 @@ in the same change. `AGENTS.md` states the compliance rule.
 
 ## Commands
 
-Not yet specified: `encrypt`, `decrypt`, `update`, and the global `--passphrase-stdin` option.
+All commands take a passphrase: interactively from the terminal with echo disabled, or — when the global
+`--passphrase-stdin` option is given — from standard input, read to end-of-input and used exactly as provided (trailing
+newlines are NOT stripped, and the passphrase need not be valid UTF-8). On any failure, commands exit with a nonzero
+status and report the error on standard error.
+
+Not yet specified: `encrypt`, and `update`'s write behavior (which format it writes and how). `update`'s validation read
+IS specified below.
+
+### decrypt
+
+`saltybox decrypt -i <input> -o <output>` reads an armored saltybox file from `<input>` and writes the decrypted
+plaintext to `<output>`.
+
+Accepted input: a file whose entire contents are valid UTF-8 consisting of one armored saltybox unit in any supported
+format (see File formats). The format is selected by the magic prefix; both `saltybox1` and `saltybox2` inputs are
+accepted.
+
+Output is written atomically via a same-directory private temporary file: on success `<output>` contains exactly the
+plaintext, and no partial file ever appears at `<output>` under any circumstances. On any failure before the atomic
+rename, an existing file at `<output>` is left unchanged. (One narrow exception to "unchanged on failure": if making the
+rename durable fails after the rename itself succeeded, `<output>` has already been replaced — with complete contents —
+while the command still exits nonzero.) A failed or interrupted write may leave the temporary file (on Unix with
+owner-only permissions; name prefixed `.saltybox-`) behind in the output directory; rename failures report its path. On
+Unix the output file mode is 0600.
+
+Failures are diagnosed per scenario, each with a distinct message:
+
+- Input that is not valid UTF-8 is rejected before any format interpretation.
+- Input that is a proper prefix of a supported magic (including empty input) is rejected as likely truncated.
+- Input starting with `saltybox` that neither matches a supported magic nor is a proper prefix of one is rejected as an
+  unsupported (future) version.
+- Input not recognizable as saltybox data at all is rejected as unrecognized.
+- saltybox2 input that does not end with the `:end` marker is rejected as likely truncated, with a message naming the
+  missing marker (a plain-text aid; not a cryptographic check).
+- Input with a supported magic whose base64 body fails to decode is rejected as an armor decoding error.
+- Structurally malformed binary payloads — truncated fields, invalid length fields, out-of-range key-derivation
+  parameters, trailing data where the format forbids it — are rejected as format errors with a diagnostic specific to
+  the failure. These are deliberately distinct from authentication failures.
+- A wrong passphrase, or sealed data that has been tampered with or corrupted, is rejected with a single
+  authentication-failure diagnostic. There is no way to tell programmatically (or otherwise) which of the two occurred;
+  they are cryptographically indistinguishable.
+
+### update (validation read)
+
+`update` decrypts the existing encrypted file before re-encrypting new content, to validate that the passphrase matches
+(preventing accidental passphrase changes). That validation read accepts the same formats as `decrypt` and fails in the
+same scenarios with the same classifications — messages may differ in how they name the input file — and any such
+failure aborts the update leaving the existing encrypted file unchanged.
 
 ## File formats
 
-Not yet specified: the `saltybox1` armored format and its binary payload.
+An armored saltybox unit is an ASCII magic prefix identifying the format version, directly followed by the base64url
+encoding (RFC 4648 URL-safe alphabet, no padding) of a binary payload:
+
+- saltybox1: `saltybox1:` followed by the payload.
+- saltybox2: `saltybox2:` followed by the payload, terminated by the literal marker `:end`.
+
+Armored data contains no whitespace and is safe to embed in URLs and to pass unescaped to a POSIX shell. Base64 bodies
+must be canonical: padding characters and non-canonical trailing bits are rejected.
+
+The saltybox2 `:end` marker is a plain-text truncation aid: armored text gets copy-pasted, and a paste that loses its
+tail is rejected up front with a message attributing the rejection to the missing marker. The marker is deliberately not
+covered by any cryptographic check, and its presence proves nothing about integrity — that is solely the job of the
+sealed data's authentication tag. Trailing whitespace after the marker — any character with the Unicode White_Space
+property — is accepted and ignored: files routinely end with a newline, and a complete unit followed by whitespace is
+not truncated.
+
+### saltybox1
+
+Binary payload layout, in order:
+
+- salt: 8 bytes
+- nonce: 24 bytes
+- length: 8 bytes, big-endian signed 64-bit integer; the byte length of the sealed box that follows. Negative values,
+  and values exceeding the available input, are rejected as format errors.
+- sealed box: NaCl secretbox (XSalsa20-Poly1305) output — a 16-byte Poly1305 tag followed by the ciphertext. The sealed
+  box is always exactly 16 bytes longer than the plaintext; the plaintext is encrypted as provided, with no padding and
+  no metadata.
+
+Data after the sealed box is rejected as a format error.
+
+Key derivation: scrypt over the passphrase and salt with N=32768 (2^15), r=8, p=1, producing a 32-byte key. These
+parameters are fixed properties of the saltybox1 format.
+
+### saltybox2
+
+Binary payload layout, in order:
+
+- salt: 16 bytes
+- m: unsigned 32-bit big-endian integer, Argon2 memory cost in KiB
+- t: unsigned 32-bit big-endian integer, Argon2 time cost (passes)
+- p: unsigned 32-bit big-endian integer, Argon2 parallelism (lanes)
+- nonce: 24 bytes
+- sealed data: XChaCha20-Poly1305 output — the ciphertext followed by a 16-byte Poly1305 tag — extending to the end of
+  the payload. There is no length field, and trailing data is therefore impossible by construction. Empty plaintext is
+  valid: the sealed data is then exactly the 16-byte tag.
+
+Key derivation: Argon2id version 0x13 over the passphrase and salt with the m, t, p values from the header, producing a
+32-byte key. The Argon2 version and key length are fixed properties of the saltybox2 format.
+
+Key-derivation parameters are validated BEFORE any key derivation work, so a hostile file cannot cause large memory or
+CPU consumption via its header. The accepted ranges are:
+
+- t: at least 1, at most 64
+- p: at least 1, at most 8
+- m: at most 4194304 KiB (4 GiB), and at least 8×p KiB (the Argon2 minimum)
+
+Out-of-range parameters are a format error, deliberately distinct from authentication failure. Any in-range parameter
+combination decrypts normally; readers must not assume files were written with any particular parameter values.
+
+The AEAD associated data is the ASCII armor magic `saltybox2:` concatenated with the entire header (salt, m, t, p,
+nonce). A successful decrypt therefore proves the whole envelope — version identifier included — was untampered.

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -581,6 +581,55 @@ mod tests {
         assert_eq!(fs::read(&decrypted_path).unwrap(), b"old plaintext");
     }
 
+    /// Pins the tempfile contract SPEC.md makes normative: the temporary
+    /// file is created in the output directory with the ".saltybox-" prefix
+    /// and owner-only permissions, and a failed rename reports the
+    /// tempfile's path so the user can clean it up. The rename is forced to
+    /// fail by making the output path an existing directory.
+    #[test]
+    #[cfg(unix)]
+    fn test_failed_rename_reports_private_tempfile() {
+        let temp_dir = TempDir::new().unwrap();
+        let plain_path = temp_dir.path().join("plain.txt");
+        let crypt_path = temp_dir.path().join("occupied");
+
+        fs::write(&plain_path, b"secret").unwrap();
+        fs::create_dir(&crypt_path).unwrap();
+
+        let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
+        let err = encrypt_file(&plain_path, &crypt_path, &mut reader)
+            .expect_err("expected rename onto a directory to fail");
+
+        // The rename-failure message travels in the error source chain and
+        // must point at the leftover tempfile.
+        let mut chain_msg = None;
+        let mut source: Option<&(dyn std::error::Error + 'static)> = Some(&err);
+        while let Some(e) = source {
+            let msg = e.to_string();
+            if msg.contains("tempfile may still exist at") {
+                chain_msg = Some(msg);
+                break;
+            }
+            source = e.source();
+        }
+        let msg = chain_msg.expect("expected rename failure to report the tempfile path");
+        let tempfile_path = msg
+            .split("tempfile may still exist at ")
+            .nth(1)
+            .and_then(|rest| rest.split(" and may need manual removal").next())
+            .expect("expected the message to embed the tempfile path");
+
+        let tempfile_path = std::path::Path::new(tempfile_path);
+        assert!(tempfile_path.exists(), "leftover tempfile should exist");
+        let name = tempfile_path.file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with(".saltybox-"), "name: {name}");
+        assert!(name.ends_with(".tmp"), "name: {name}");
+        assert_eq!(tempfile_path.parent().unwrap(), temp_dir.path());
+
+        let mode = fs::metadata(tempfile_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "tempfile must be owner-only");
+    }
+
     #[test]
     fn test_encrypt_to_missing_output_directory_is_user_error() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/format.rs
+++ b/src/format.rs
@@ -13,6 +13,7 @@
 //! because a new format was added.
 
 use crate::error::{ErrorCategory, ErrorKind, Result, SaltyboxError};
+use crate::format_v2::V2Engine;
 use crate::{secretcrypt_v1, varmor};
 use zeroize::Zeroizing;
 
@@ -90,7 +91,9 @@ impl FormatEngine for V1Engine {
 }
 
 /// Every supported engine, in the order the read side tries their magics.
-const ENGINES: &[&dyn FormatEngine] = &[&V1Engine];
+///
+/// Engines are never removed: every format ever written stays decryptable.
+const ENGINES: &[&dyn FormatEngine] = &[&V1Engine, &V2Engine];
 
 /// The engine used for all newly written files.
 ///
@@ -118,14 +121,17 @@ pub fn decode(armored: &str) -> Result<(&'static dyn FormatEngine, Vec<u8>)> {
 /// Select the engine for an armored input by its magic.
 ///
 /// Inputs matching no supported magic are diagnosed per scenario: a proper
-/// prefix of a supported magic reads as likely truncation, a `saltybox`
+/// prefix of any supported magic reads as likely truncation, a `saltybox`
 /// prefix that matches no supported version as coming from a future
 /// saltybox, and anything else as not saltybox data at all.
 ///
 /// The CLI's diagnostics for unrecognized input come from here: raw input
-/// is classified before any engine sees it. [`varmor::unwrap`] carries
-/// equivalent branches with identical message strings for its direct
-/// callers; the duplication is deliberate, keeping varmor self-contained.
+/// is classified before any engine sees it, relative to the full set of
+/// supported versions — bare "saltybox2" reads as likely truncation, for
+/// example, since it is a proper prefix of a supported magic.
+/// [`varmor::unwrap`] carries equivalent v1-only branches with identical
+/// message strings for its direct callers; the duplication is deliberate,
+/// keeping varmor self-contained.
 pub fn engine_for(armored: &str) -> Result<&'static dyn FormatEngine> {
     for engine in ENGINES {
         if armored.starts_with(engine.magic()) {
@@ -182,13 +188,28 @@ mod tests {
         }
 
         #[test]
+        fn engine_for_selects_v2() {
+            let armored = V2Engine.encrypt(b"pw", b"payload").unwrap();
+            let engine = engine_for(&armored).unwrap();
+            assert_eq!(engine.magic(), "saltybox2:");
+        }
+
+        #[test]
         fn roundtrip_through_dispatch() {
             let plaintext = b"hello world";
             let armored = default_write_engine().encrypt(b"pw", plaintext).unwrap();
 
-            let Ok((engine, payload)) = decode(&armored) else {
-                panic!("expected decode to succeed")
-            };
+            let (engine, payload) = decode(&armored).unwrap();
+            let decrypted = engine.decrypt(b"pw", &payload).unwrap();
+            assert_eq!(plaintext, &decrypted[..]);
+        }
+
+        #[test]
+        fn v2_roundtrip_through_dispatch() {
+            let plaintext = b"v2 dispatch roundtrip";
+            let armored = V2Engine.encrypt(b"pw", plaintext).unwrap();
+
+            let (engine, payload) = decode(&armored).unwrap();
             let decrypted = engine.decrypt(b"pw", &payload).unwrap();
             assert_eq!(plaintext, &decrypted[..]);
         }
@@ -199,15 +220,37 @@ mod tests {
             // malformed body still selects that engine, whose unarmor then
             // reports the decode error.
             let input = "saltybox1:bad$$";
-            let Ok(engine) = engine_for(input) else {
-                panic!("expected dispatch to succeed for {input:?}")
-            };
+            let engine = engine_for(input).unwrap();
             assert_eq!(engine.magic(), "saltybox1:");
 
             let err = engine
                 .unarmor(input)
                 .expect_err("expected base64 decode failure");
             assert_eq!(err.kind, Some(ErrorKind::ArmoringDecode));
+        }
+
+        #[test]
+        fn unarmor_rejects_non_canonical_base64() {
+            // SPEC.md requires canonical armor: padding characters ("AA==") and
+            // non-zero trailing bits ("AB") must be rejected. This currently
+            // holds via the base64 crate's URL_SAFE_NO_PAD defaults; pinning it
+            // here keeps a dependency upgrade from silently loosening the format.
+            for input in [
+                "saltybox1:AA==",
+                "saltybox2:AA==:end",
+                "saltybox1:AB",
+                "saltybox2:AB:end",
+            ] {
+                let engine = engine_for(input).unwrap();
+                let err = engine
+                    .unarmor(input)
+                    .expect_err(&format!("expected canonicality rejection for {input:?}"));
+                assert_eq!(
+                    err.kind,
+                    Some(ErrorKind::ArmoringDecode),
+                    "input: {input:?}"
+                );
+            }
         }
 
         #[test]
@@ -233,7 +276,9 @@ mod tests {
 
         #[test]
         fn prefix_of_magic_is_truncated() {
-            for input in ["", "salt", "saltybox", "saltybox1"] {
+            // Bare "saltybox2" is a proper prefix of the saltybox2 magic, so it
+            // reads as likely truncation rather than as an unsupported version.
+            for input in ["", "salt", "saltybox", "saltybox1", "saltybox2"] {
                 let Err(err) = engine_for(input) else {
                     panic!("expected error for {input:?}")
                 };
@@ -252,7 +297,7 @@ mod tests {
 
         #[test]
         fn unsupported_version_is_from_future() {
-            for input in ["saltybox2", "saltybox999999:..."] {
+            for input in ["saltybox3", "saltybox3:...", "saltybox999999:..."] {
                 let Err(err) = engine_for(input) else {
                     panic!("expected error for {input:?}")
                 };

--- a/src/varmor.rs
+++ b/src/varmor.rs
@@ -154,8 +154,12 @@ mod tests {
     #[test]
     fn test_short_wrong_version_is_from_future() {
         // Shorter than the v1 magic but already diverged from it after the
-        // "saltybox" prefix: the unsupported-version diagnosis is accurate,
-        // not truncation.
+        // "saltybox" prefix: from varmor's v1-only view the
+        // unsupported-version diagnosis is accurate, not truncation. This
+        // pins varmor's internal contract only — the CLI's user-visible
+        // classification lives in format::engine_for, which knows the full set of
+        // supported versions (and diagnoses bare "saltybox2" as truncation)
+        // and intercepts input before varmor ever sees it.
         let result = unwrap("saltybox2");
         let err = result.expect_err("expected unsupported version error");
         assert_eq!(err.kind, Some(ErrorKind::ArmoringFromFuture));

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -18,6 +18,15 @@ fn run_saltybox_with_passphrase(
     args: &[&str],
     passphrase: &str,
 ) -> Result<std::process::Output, std::io::Error> {
+    run_saltybox_with_passphrase_bytes(args, passphrase.as_bytes())
+}
+
+/// Like [`run_saltybox_with_passphrase`], for passphrases that are not
+/// valid UTF-8 — SPEC.md says the passphrase is arbitrary bytes.
+fn run_saltybox_with_passphrase_bytes(
+    args: &[&str],
+    passphrase: &[u8],
+) -> Result<std::process::Output, std::io::Error> {
     let mut child = Command::new(saltybox_bin())
         .arg("--passphrase-stdin")
         .args(args)
@@ -32,7 +41,7 @@ fn run_saltybox_with_passphrase(
         .stdin
         .as_mut()
         .expect("failed to open stdin")
-        .write_all(passphrase.as_bytes())
+        .write_all(passphrase)
         .err()
         .filter(|err| err.kind() != io::ErrorKind::BrokenPipe);
     drop(child.stdin.take());
@@ -51,6 +60,251 @@ fn testdata_path(filename: &str) -> PathBuf {
     path.push("testdata");
     path.push(filename);
     path
+}
+
+/// A known saltybox2 unit from testdata/golden-vectors-v2.json ("basic
+/// text"): passphrase "test", plaintext "test payload". Duplicated here as a
+/// literal so the CLI tests read as self-contained end-to-end scenarios.
+const V2_FIXTURE: &str = "saltybox2:AAECAwQFBgcICQoLDA0ODwAAIAAAAAADAAAAAQABAgMEBQYHCAkKCwwNDg8QERITFBUWFwzD0jEQJtkCSl0SBslcxc9u0TKUcd-9COPdAIg:end";
+const V2_FIXTURE_PASSPHRASE: &str = "test";
+const V2_FIXTURE_PLAINTEXT: &str = "test payload";
+
+/// Decrypting a saltybox2 file must work unconditionally — no flag or
+/// environment variable involved.
+#[test]
+fn test_decrypt_known_v2_ciphertext() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("v2.salty");
+    let output = temp_dir.path().join("v2-decrypted.txt");
+
+    fs::write(&input, V2_FIXTURE).unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ],
+        V2_FIXTURE_PASSPHRASE,
+    )
+    .unwrap();
+
+    assert!(
+        result.status.success(),
+        "v2 decrypt failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(fs::read_to_string(&output).unwrap(), V2_FIXTURE_PLAINTEXT);
+}
+
+/// A trailing newline after the ":end" marker is an everyday file artifact,
+/// not truncation: decrypt must accept it.
+#[test]
+fn test_decrypt_v2_accepts_trailing_newline() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("v2-newline.salty");
+    let output = temp_dir.path().join("out.txt");
+
+    fs::write(&input, format!("{V2_FIXTURE}\n")).unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ],
+        V2_FIXTURE_PASSPHRASE,
+    )
+    .unwrap();
+
+    assert!(
+        result.status.success(),
+        "decrypt with trailing newline failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(fs::read_to_string(&output).unwrap(), V2_FIXTURE_PLAINTEXT);
+}
+
+/// A saltybox2 paste that lost its tail is caught by the ":end" marker
+/// check. The wording must name the missing plain-text marker — it is a
+/// transport aid, and must not read as a cryptographic verdict.
+#[test]
+fn test_decrypt_v2_missing_end_marker_reports_truncation() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("truncated-v2.salty");
+    let output = temp_dir.path().join("out.txt");
+
+    let pasted_short = &V2_FIXTURE[..V2_FIXTURE.len() - 7];
+    fs::write(&input, pasted_short).unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ],
+        V2_FIXTURE_PASSPHRASE,
+    )
+    .unwrap();
+
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("does not end with the \":end\" marker")
+            && stderr.contains("likely truncated"),
+        "expected missing-marker truncation diagnostic, got: {stderr}"
+    );
+    assert!(!output.exists());
+}
+
+/// update must accept a saltybox2 file on its validation read.
+#[test]
+fn test_update_accepts_v2_encrypted_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let new_plain = temp_dir.path().join("new.txt");
+    let encrypted = temp_dir.path().join("v2.salty");
+    let decrypted = temp_dir.path().join("decrypted.txt");
+
+    fs::write(&encrypted, V2_FIXTURE).unwrap();
+    fs::write(&new_plain, "updated via v2 validation").unwrap();
+
+    // Wrong passphrase must be caught by the v2 validation read.
+    let update_args = [
+        "update",
+        "-i",
+        new_plain.to_str().unwrap(),
+        "-o",
+        encrypted.to_str().unwrap(),
+    ];
+    let result = run_saltybox_with_passphrase(&update_args, "wrong").unwrap();
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("failed to decrypt"),
+        "expected authentication failure from the v2 validation read, got: {stderr}"
+    );
+    assert_eq!(fs::read_to_string(&encrypted).unwrap(), V2_FIXTURE);
+
+    let result = run_saltybox_with_passphrase(&update_args, V2_FIXTURE_PASSPHRASE).unwrap();
+    assert!(
+        result.status.success(),
+        "update over v2 file failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            encrypted.to_str().unwrap(),
+            "-o",
+            decrypted.to_str().unwrap(),
+        ],
+        V2_FIXTURE_PASSPHRASE,
+    )
+    .unwrap();
+    assert!(result.status.success());
+    assert_eq!(
+        fs::read_to_string(&decrypted).unwrap(),
+        "updated via v2 validation"
+    );
+}
+
+/// The transition plan (lore/2026-07-01-saltybox2.md) lands saltybox2 read
+/// support before any write-side change: encrypt must keep writing saltybox1
+/// until the default is deliberately flipped in a later step.
+#[test]
+fn test_encrypt_still_writes_saltybox1() {
+    let temp_dir = TempDir::new().unwrap();
+    let plaintext = temp_dir.path().join("plain.txt");
+    let encrypted = temp_dir.path().join("out.salty");
+
+    fs::write(&plaintext, "format check").unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "encrypt",
+            "-i",
+            plaintext.to_str().unwrap(),
+            "-o",
+            encrypted.to_str().unwrap(),
+        ],
+        "test",
+    )
+    .unwrap();
+    assert!(result.status.success());
+    assert!(
+        fs::read_to_string(&encrypted)
+            .unwrap()
+            .starts_with("saltybox1:")
+    );
+}
+
+/// Bare "saltybox2" is a proper prefix of a supported magic and is
+/// diagnosed as likely truncation.
+#[test]
+fn test_decrypt_bare_supported_magic_prefix_is_truncation_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("truncated.salty");
+    let output = temp_dir.path().join("out.txt");
+
+    fs::write(&input, "saltybox2").unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ],
+        "test",
+    )
+    .unwrap();
+
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("likely truncated"),
+        "expected truncation diagnostic, got: {stderr}"
+    );
+    assert!(!output.exists());
+}
+
+/// Versions above the supported set must get the future-version diagnostic.
+#[test]
+fn test_decrypt_future_version_is_unsupported_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path().join("future.salty");
+    let output = temp_dir.path().join("out.txt");
+
+    fs::write(&input, "saltybox3:AAAA").unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ],
+        "test",
+    )
+    .unwrap();
+
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("not a version we support"),
+        "expected future-version diagnostic, got: {stderr}"
+    );
+    assert!(!output.exists());
 }
 
 /// Decrypt known ciphertext.
@@ -184,6 +438,64 @@ fn test_output_path_without_directory_component_roundtrip() {
     assert_eq!(
         fs::read_to_string(temp_dir.path().join("decrypted.txt")).unwrap(),
         "bare relative output"
+    );
+}
+
+/// SPEC.md: the passphrase is used exactly as provided and need not be
+/// valid UTF-8. Pinned end-to-end through --passphrase-stdin so a
+/// String-typed regression in the binary's stdin wiring cannot hide behind
+/// the unit-level coverage.
+#[test]
+fn test_non_utf8_passphrase_roundtrips() {
+    let temp_dir = TempDir::new().unwrap();
+    let plaintext = temp_dir.path().join("plain.txt");
+    let encrypted = temp_dir.path().join("out.salty");
+    let decrypted = temp_dir.path().join("decrypted.txt");
+
+    let passphrase: &[u8] = &[0xff, 0xfe, 0x00, 0x01];
+    fs::write(&plaintext, "non-utf8 passphrase content").unwrap();
+
+    let result = run_saltybox_with_passphrase_bytes(
+        &[
+            "encrypt",
+            "-i",
+            plaintext.to_str().unwrap(),
+            "-o",
+            encrypted.to_str().unwrap(),
+        ],
+        passphrase,
+    )
+    .unwrap();
+    assert!(
+        result.status.success(),
+        "encrypt with non-UTF-8 passphrase failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let decrypt_args = [
+        "decrypt",
+        "-i",
+        encrypted.to_str().unwrap(),
+        "-o",
+        decrypted.to_str().unwrap(),
+    ];
+
+    // A lossy re-encoding of the same bytes must NOT work: that would mean
+    // the passphrase was routed through a String somewhere.
+    let lossy = String::from_utf8_lossy(passphrase).into_owned();
+    let result = run_saltybox_with_passphrase(&decrypt_args, &lossy).unwrap();
+    assert!(!result.status.success());
+    assert!(!decrypted.exists());
+
+    let result = run_saltybox_with_passphrase_bytes(&decrypt_args, passphrase).unwrap();
+    assert!(
+        result.status.success(),
+        "decrypt with non-UTF-8 passphrase failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&decrypted).unwrap(),
+        "non-utf8 passphrase content"
     );
 }
 


### PR DESCRIPTION
Step 5 of lore/2026-07-01-saltybox2.md: decrypt (and update's validation read) now accept saltybox2 unconditionally; encrypt/update still write only saltybox1. SPEC.md gains the byte-level saltybox1 and saltybox2 format sections and the decrypt error taxonomy. One deliberate taxonomy shift: bare "saltybox2" now diagnoses as likely-truncated instead of future-version, since it is a proper prefix of a supported magic.

changelog: include
