### PR TITLE
refactor: make the write-format engine an explicit parameter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -15,8 +15,20 @@ All commands take a passphrase: interactively from the terminal with echo disabl
 newlines are NOT stripped, and the passphrase need not be valid UTF-8). On any failure, commands exit with a nonzero
 status and report the error on standard error.
 
-Not yet specified: `encrypt`, and `update`'s write behavior (which format it writes and how). `update`'s validation read
-IS specified below.
+Commands write their output file atomically via a same-directory private temporary file: on success the output contains
+exactly the intended bytes, and no partial file ever appears at the output path under any circumstances. On any failure
+before the atomic rename, an existing file at the output path is left unchanged. (One narrow exception to "unchanged on
+failure": if making the rename durable fails after the rename itself succeeded, the output has already been replaced —
+with complete contents — while the command still exits nonzero.) A failed or interrupted write may leave the temporary
+file (on Unix with owner-only permissions; name prefixed `.saltybox-`) behind in the output directory; rename failures
+report its path. On Unix the final output file mode is 0600.
+
+### encrypt
+
+`saltybox encrypt -i <input> -o <output>` reads plaintext from `<input>` — any byte sequence, including empty — and
+writes one armored saltybox unit to `<output>` in the saltybox1 format. The output format never depends on any existing
+file. Salt and nonce are freshly generated at random for every encryption, so encrypting the same input twice produces
+different output.
 
 ### decrypt
 
@@ -26,14 +38,6 @@ plaintext to `<output>`.
 Accepted input: a file whose entire contents are valid UTF-8 consisting of one armored saltybox unit in any supported
 format (see File formats). The format is selected by the magic prefix; both `saltybox1` and `saltybox2` inputs are
 accepted.
-
-Output is written atomically via a same-directory private temporary file: on success `<output>` contains exactly the
-plaintext, and no partial file ever appears at `<output>` under any circumstances. On any failure before the atomic
-rename, an existing file at `<output>` is left unchanged. (One narrow exception to "unchanged on failure": if making the
-rename durable fails after the rename itself succeeded, `<output>` has already been replaced — with complete contents —
-while the command still exits nonzero.) A failed or interrupted write may leave the temporary file (on Unix with
-owner-only permissions; name prefixed `.saltybox-`) behind in the output directory; rename failures report its path. On
-Unix the output file mode is 0600.
 
 Failures are diagnosed per scenario, each with a distinct message:
 
@@ -52,12 +56,20 @@ Failures are diagnosed per scenario, each with a distinct message:
   authentication-failure diagnostic. There is no way to tell programmatically (or otherwise) which of the two occurred;
   they are cryptographically indistinguishable.
 
-### update (validation read)
+### update
 
-`update` decrypts the existing encrypted file before re-encrypting new content, to validate that the passphrase matches
-(preventing accidental passphrase changes). That validation read accepts the same formats as `decrypt` and fails in the
-same scenarios with the same classifications — messages may differ in how they name the input file — and any such
-failure aborts the update leaving the existing encrypted file unchanged.
+`saltybox update -i <input> -o <existing>` replaces the contents of the existing encrypted file `<existing>` with newly
+encrypted plaintext from `<input>`, validating first that the passphrase matches the existing file (preventing
+accidental passphrase changes). `<input>` and `<existing>` must be different files; identical paths and aliases of the
+same file via symlinks or path traversal are rejected, and on Unix, hard-link aliases are rejected as well.
+
+The validation read decrypts `<existing>`, accepting the same formats as `decrypt` and failing in the same scenarios
+with the same classifications (messages may differ in how they name the input file). Any failure — including a wrong
+passphrase — aborts the update and leaves `<existing>` unchanged.
+
+On successful validation, the new plaintext is encrypted with the validated passphrase and written atomically over
+`<existing>`, always in the current write format (saltybox1), regardless of the existing file's format: updating a
+saltybox2 file rewrites it as saltybox1 — a format downgrade.
 
 ## File formats
 

--- a/src/bin/saltybox.rs
+++ b/src/bin/saltybox.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::process;
 
 use saltybox::file_ops;
+use saltybox::format;
 use saltybox::passphrase::{PassphraseReader, ReaderPassphraseReader, TerminalPassphraseReader};
 
 #[derive(Parser)]
@@ -68,14 +69,17 @@ fn main() {
     let cli = Cli::parse();
 
     let mut reader = get_passphrase_reader(cli.passphrase_stdin);
+    let write_engine = format::default_write_engine();
     let result = match cli.command {
         Commands::Encrypt { input, output } => {
-            file_ops::encrypt_file(&input, &output, &mut *reader)
+            file_ops::encrypt_file(&input, &output, &mut *reader, write_engine)
         }
         Commands::Decrypt { input, output } => {
             file_ops::decrypt_file(&input, &output, &mut *reader)
         }
-        Commands::Update { input, output } => file_ops::update_file(&input, &output, &mut *reader),
+        Commands::Update { input, output } => {
+            file_ops::update_file(&input, &output, &mut *reader, write_engine)
+        }
     };
 
     if let Err(e) = result {

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -19,16 +19,20 @@ const TEMPFILE_SUFFIX: &str = ".tmp";
 /// Reads plaintext from `input_path`, encrypts it using a passphrase from
 /// `passphrase_reader`, and writes the armored ciphertext to `output_path`.
 ///
+/// Which format is written is the caller's choice via `write_engine`; the
+/// CLI always passes [`format::default_write_engine`].
+///
 /// Output is written atomically via a same-directory temporary file.
 /// On Unix systems, the final file mode is set to 0o600 (read/write for owner only).
 pub fn encrypt_file(
     input_path: &Path,
     output_path: &Path,
     passphrase_reader: &mut dyn PassphraseReader,
+    write_engine: &dyn format::FormatEngine,
 ) -> Result<()> {
     let plaintext = Zeroizing::new(fs::read(input_path).map_err(|e| read_error(input_path, e))?);
     let passphrase = passphrase_reader.read_passphrase()?;
-    let armored = format::default_write_engine()
+    let armored = write_engine
         .encrypt(&passphrase, &plaintext)
         .map_err(|e| e.with_context("encryption failed"))?;
     write_file_secure(output_path, armored.as_bytes())
@@ -81,10 +85,15 @@ pub fn decrypt_file(
 /// never a partial/corrupted file.
 ///
 /// The passphrase validation prevents accidental passphrase changes.
+///
+/// The output format follows `write_engine` alone, never the existing file's
+/// format: updating with a different engine than the file was written with
+/// silently converts it (this is the intended migration path).
 pub fn update_file(
     plain_path: &Path,
     crypt_path: &Path,
     passphrase_reader: &mut dyn PassphraseReader,
+    write_engine: &dyn format::FormatEngine,
 ) -> Result<()> {
     // Prevent treating the existing ciphertext as new plaintext when paths alias.
     if update_paths_conflict(plain_path, crypt_path) {
@@ -115,7 +124,7 @@ pub fn update_file(
 
     let new_plaintext =
         Zeroizing::new(fs::read(plain_path).map_err(|e| read_error(plain_path, e))?);
-    let new_armored = format::default_write_engine()
+    let new_armored = write_engine
         .encrypt(&passphrase, &new_plaintext)
         .map_err(|e| e.with_context("failed to encrypt"))?;
     write_file_secure(crypt_path, new_armored.as_bytes())?;
@@ -300,12 +309,44 @@ fn read_error(path: &Path, err: io::Error) -> SaltyboxError {
 mod tests {
     use super::*;
     use crate::error::{ErrorCategory, ErrorKind};
+    use crate::format_v2::V2Engine;
     use crate::passphrase::ConstantPassphraseReader;
     use std::fs;
     use tempfile::TempDir;
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    /// Most tests here exercise file-handling behavior that does not depend
+    /// on which format is written; these wrappers keep those call sites
+    /// one-liners. Tests where the engine choice is the point pass engines
+    /// to [`encrypt_file`]/[`update_file`] explicitly.
+    fn encrypt_with_default_engine(
+        input_path: &Path,
+        output_path: &Path,
+        passphrase_reader: &mut dyn PassphraseReader,
+    ) -> Result<()> {
+        encrypt_file(
+            input_path,
+            output_path,
+            passphrase_reader,
+            format::default_write_engine(),
+        )
+    }
+
+    /// See [`encrypt_with_default_engine`].
+    fn update_with_default_engine(
+        plain_path: &Path,
+        crypt_path: &Path,
+        passphrase_reader: &mut dyn PassphraseReader,
+    ) -> Result<()> {
+        update_file(
+            plain_path,
+            crypt_path,
+            passphrase_reader,
+            format::default_write_engine(),
+        )
+    }
 
     #[test]
     fn test_encrypt_decrypt_roundtrip() {
@@ -318,13 +359,80 @@ mod tests {
         fs::write(&plain_path, plaintext).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
         assert!(crypt_path.exists());
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
         decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();
         let decrypted = fs::read(&decrypted_path).unwrap();
         assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_file_with_v2_engine_roundtrips() {
+        let temp_dir = TempDir::new().unwrap();
+        let plain_path = temp_dir.path().join("plain.txt");
+        let crypt_path = temp_dir.path().join("crypt.txt.saltybox");
+        let decrypted_path = temp_dir.path().join("decrypted.txt");
+
+        fs::write(&plain_path, b"v2 write path").unwrap();
+
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        encrypt_file(&plain_path, &crypt_path, &mut reader, &V2Engine).unwrap();
+        assert!(
+            fs::read_to_string(&crypt_path)
+                .unwrap()
+                .starts_with("saltybox2:")
+        );
+
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();
+        assert_eq!(fs::read(&decrypted_path).unwrap(), b"v2 write path");
+    }
+
+    /// The output format follows the write engine alone: updating a v1 file
+    /// with the v2 engine upgrades it, and updating a v2 file with the v1
+    /// engine downgrades it. Both directions must round-trip.
+    #[test]
+    fn test_update_output_format_follows_write_engine_not_input() {
+        let temp_dir = TempDir::new().unwrap();
+        let plain_path = temp_dir.path().join("plain.txt");
+        let crypt_path = temp_dir.path().join("crypt.txt.saltybox");
+        let decrypted_path = temp_dir.path().join("decrypted.txt");
+
+        fs::write(&plain_path, b"original").unwrap();
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
+        assert!(
+            fs::read_to_string(&crypt_path)
+                .unwrap()
+                .starts_with("saltybox1:")
+        );
+
+        fs::write(&plain_path, b"upgraded").unwrap();
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        update_file(&plain_path, &crypt_path, &mut reader, &V2Engine).unwrap();
+        assert!(
+            fs::read_to_string(&crypt_path)
+                .unwrap()
+                .starts_with("saltybox2:")
+        );
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();
+        assert_eq!(fs::read(&decrypted_path).unwrap(), b"upgraded");
+
+        fs::write(&plain_path, b"downgraded").unwrap();
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        update_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
+        assert!(
+            fs::read_to_string(&crypt_path)
+                .unwrap()
+                .starts_with("saltybox1:")
+        );
+
+        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
+        decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();
+        assert_eq!(fs::read(&decrypted_path).unwrap(), b"downgraded");
     }
 
     #[test]
@@ -338,13 +446,13 @@ mod tests {
         fs::write(&plain1_path, plaintext1).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        encrypt_file(&plain1_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain1_path, &crypt_path, &mut reader).unwrap();
 
         let plaintext2 = b"Updated content";
         fs::write(&plain2_path, plaintext2).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        update_file(&plain2_path, &crypt_path, &mut reader).unwrap();
+        update_with_default_engine(&plain2_path, &crypt_path, &mut reader).unwrap();
 
         let decrypted_path = temp_dir.path().join("decrypted.txt");
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
@@ -364,10 +472,10 @@ mod tests {
         fs::write(&plain_path, original).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        let result = update_file(&crypt_path, &crypt_path, &mut reader);
+        let result = update_with_default_engine(&crypt_path, &crypt_path, &mut reader);
 
         let err = result.expect_err("expected path conflict failure");
         assert_eq!(err.category, ErrorCategory::User);
@@ -396,12 +504,12 @@ mod tests {
         fs::write(&plain_path, original).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         fs::create_dir(&alias_dir).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        let result = update_file(&alias_path, &crypt_path, &mut reader);
+        let result = update_with_default_engine(&alias_path, &crypt_path, &mut reader);
 
         let err = result.expect_err("expected canonical path conflict failure");
         assert_eq!(err.category, ErrorCategory::User);
@@ -430,14 +538,14 @@ mod tests {
         fs::write(&plain_path, original).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         // A hardlink canonicalizes to its own path, so only the inode check
         // can catch this alias.
         fs::hard_link(&crypt_path, &hardlink_path).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test password".to_vec());
-        let result = update_file(&hardlink_path, &crypt_path, &mut reader);
+        let result = update_with_default_engine(&hardlink_path, &crypt_path, &mut reader);
 
         let err = result.expect_err("expected hardlink path conflict failure");
         assert_eq!(err.category, ErrorCategory::User);
@@ -463,11 +571,11 @@ mod tests {
 
         fs::write(&plain1_path, b"Initial").unwrap();
         let mut reader = ConstantPassphraseReader::new(b"correct password".to_vec());
-        encrypt_file(&plain1_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain1_path, &crypt_path, &mut reader).unwrap();
 
         fs::write(&plain2_path, b"Updated").unwrap();
         let mut reader = ConstantPassphraseReader::new(b"wrong password".to_vec());
-        let result = update_file(&plain2_path, &crypt_path, &mut reader);
+        let result = update_with_default_engine(&plain2_path, &crypt_path, &mut reader);
 
         let err = result.expect_err("expected authentication failure");
         assert_eq!(err.kind, Some(ErrorKind::AuthenticationFailed));
@@ -489,7 +597,7 @@ mod tests {
         fs::write(&plain_path, b"test").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let metadata = fs::metadata(&crypt_path).unwrap();
         let permissions = metadata.permissions();
@@ -510,7 +618,7 @@ mod tests {
         fs::set_permissions(&crypt_path, permissions).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let metadata = fs::metadata(&crypt_path).unwrap();
         let permissions = metadata.permissions();
@@ -528,7 +636,7 @@ mod tests {
         fs::write(&plain_path, b"secret").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         fs::write(&decrypted_path, b"old plaintext").unwrap();
         let mut permissions = fs::metadata(&decrypted_path).unwrap().permissions();
@@ -557,7 +665,7 @@ mod tests {
         fs::write(&decrypted_path, b"old plaintext").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let original_permissions = fs::metadata(&output_dir).unwrap().permissions();
         let mut unwritable_permissions = original_permissions.clone();
@@ -597,7 +705,7 @@ mod tests {
         fs::create_dir(&crypt_path).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        let err = encrypt_file(&plain_path, &crypt_path, &mut reader)
+        let err = encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader)
             .expect_err("expected rename onto a directory to fail");
 
         // The rename-failure message travels in the error source chain and
@@ -642,7 +750,7 @@ mod tests {
         fs::write(&plain_path, b"secret").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        let result = encrypt_file(&plain_path, &crypt_path, &mut reader);
+        let result = encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader);
 
         let err = result.expect_err("expected missing output directory failure");
         assert_eq!(err.category, ErrorCategory::User);
@@ -677,7 +785,7 @@ mod tests {
         fs::write(&plain_path, b"secret").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"correct".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"wrong".to_vec());
         let result = decrypt_file(&crypt_path, &decrypted_path, &mut reader);
@@ -697,7 +805,7 @@ mod tests {
         fs::write(&decrypted_path, b"old plaintext").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"correct".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"wrong".to_vec());
         assert!(decrypt_file(&crypt_path, &decrypted_path, &mut reader).is_err());
@@ -732,7 +840,7 @@ mod tests {
         fs::write(&crypt_path, [0xff]).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        let result = update_file(&plain_path, &crypt_path, &mut reader);
+        let result = update_with_default_engine(&plain_path, &crypt_path, &mut reader);
 
         let err = result.expect_err("expected UTF-8 rejection");
         assert_eq!(err.category, ErrorCategory::User);
@@ -751,7 +859,7 @@ mod tests {
         fs::write(&plain_path, b"").unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
-        encrypt_file(&plain_path, &crypt_path, &mut reader).unwrap();
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
 
         let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
         decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -197,6 +197,14 @@ fn test_update_accepts_v2_encrypted_file() {
         "update over v2 file failed: {}",
         String::from_utf8_lossy(&result.stderr)
     );
+    // Per SPEC.md, update always writes the current write format (saltybox1),
+    // regardless of the existing file's format: updating a saltybox2 file
+    // downgrades it.
+    assert!(
+        fs::read_to_string(&encrypted)
+            .unwrap()
+            .starts_with("saltybox1:")
+    );
 
     let result = run_saltybox_with_passphrase(
         &[


### PR DESCRIPTION
Step 6 of lore/2026-07-01-saltybox2.md, simplified: encrypt and update receive the format engine to write with as an explicit parameter, with the CLI passing `format::default_write_engine()` (still saltybox1). SPEC.md gains the previously deferred encrypt/update write-side sections, including that the output format never follows the existing file's format (updating a saltybox2 file today downgrades it to saltybox1). No user-visible behavior changes.

This prepares the flip: the follow-up PR only has to turn `default_write_engine()` (and the docs and tests pinned to it), keeping the behavior-changing diff small and legible.

Deviation from the plan: the plan called for an experimental `SALTYBOX_EXPERIMENTAL_V2` env-var gate before flipping the default. The gate is deliberately skipped — no release ships between this PR and the flip, so it could never reach a real user and would be pure churn (added, specified, tested, and deleted within the same stack).

changelog: skip
