### PR TITLE
feat!: write the saltybox2 format by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/scode/saltybox"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/scode/saltybox"
 rust-version = "1.85" # Rust 2024 edition requires 1.85+
-description = "Passphrase-based file encryption tool using NaCl secretbox"
+description = "Passphrase-based file encryption tool"
 
 [[bin]]
 name = "saltybox"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ same file) is rejected.
 - File writes use atomic same-directory temporary files named `.saltybox-*.tmp`. On Unix, these temporary files are
   written with mode `0600` and then atomically renamed into place. In the event of a crash, stale `.saltybox-*.tmp`
   files may remain and should still be private (`0600`).
-- The format is based upon well known algorithms with exceedingly simple layering on top. scrypt is used for key
-  stretching, nacl is used for encryption, and a base64 variant is used for encoding.
+- The formats are based upon well known algorithms with exceedingly simple layering on top. New files are written in the
+  saltybox2 format (Argon2id for key stretching, XChaCha20-Poly1305 for encryption); older saltybox1 files (scrypt and
+  NaCl secretbox) remain decryptable forever. A base64 variant is used for encoding in both formats.
 - The amount of code is relatively small and light on dependencies.
 
 # Guidance for use
@@ -93,6 +94,8 @@ external projects/people aside from the Rust language tools themselves remaining
 # Format/API contract
 
 - Future versions if any will remain able to decrypt data encrypted by older versions.
+- The reverse does not hold: newly written files use the saltybox2 format, which saltybox versions before 4.0 cannot
+  read. Running `update` on an old file also rewrites it as saltybox2 (this is the intended way to migrate old files).
 - The command line interface may change at any time. It is currently not intended for automated scripting (for this
   reason and others).
 - The code in this project is not meant to be consumed as a library and may be refactored or changed at will. It's
@@ -110,7 +113,51 @@ program.
 Unfortunately, I have not been able to find a tool like this that satisfies my personal criteria for what I want to
 depend on for emergency life recovery media.
 
+# Details: Encrypted File Format (saltybox format version 2)
+
+This is the format saltybox currently writes. The output is a text file containing an armored (ASCII text) string that
+represents the encrypted data. This section documents the format.
+
+## Armored (Text) Format
+
+- The contents of the file starts with the string `saltybox2:` which identifies the format.
+- This is followed by a base64url encoded (RFC 4648 Section 5, no padding) payload whose format is described below
+  ("binary format").
+  - Uses URL-safe base64 alphabet: `-` and `_` instead of `+` and `/`
+- The payload is terminated by the literal marker `:end`. The marker is a plain-text truncation aid: armored text gets
+  copy-pasted, and a paste that lost its tail is rejected up front with a message naming the missing marker. It is
+  deliberately not covered by any cryptographic check — integrity is solely the job of the authentication tag. Trailing
+  whitespace after the marker is accepted and ignored.
+- Example:
+  `saltybox2:AAECAwQFBgcICQoLDA0ODwAAIAAAAAADAAAAAQABAgMEBQYHCAkKCwwNDg8QERITFBUWFwzD0jEQJtkCSl0SBslcxc9u0TKUcd-9COPdAIg:end`
+
+## Binary Format
+
+The binary format contains the following, in order:
+
+1. **Salt** (16 bytes): Random salt used for key derivation.
+2. **m** (4 bytes): Unsigned 32-bit big-endian integer; Argon2 memory cost in KiB.
+3. **t** (4 bytes): Unsigned 32-bit big-endian integer; Argon2 time cost (passes).
+4. **p** (4 bytes): Unsigned 32-bit big-endian integer; Argon2 parallelism (lanes).
+5. **Nonce** (24 bytes): Random nonce for the XChaCha20-Poly1305 encryption.
+6. **Sealed data** (variable length): XChaCha20-Poly1305 output — the ciphertext followed by a 16-byte Poly1305
+   authentication tag — extending to the end of the payload. There is no length field, and trailing data is therefore
+   impossible by construction. Empty plaintext is valid: the sealed data is then exactly the 16-byte tag. The plaintext
+   is encrypted exactly as provided - no padding and no additional metadata.
+
+The AEAD associated data is the ASCII magic `saltybox2:` concatenated with the entire header (salt, m, t, p, nonce), so
+a successful decrypt proves the whole envelope — version identifier included — was untampered.
+
+The encryption key is derived from the user-provided passphrase and the salt using Argon2id (version 0x13) with the m,
+t, p values from the header, producing a 32-byte key. New files are written with m=262144 KiB (256 MiB), t=3, p=1.
+During decryption, the parameters are validated before any key derivation work (t at most 64, p at most 8, m at most
+4194304 KiB and at least 8×p KiB), so a hostile file cannot cause large memory or CPU consumption via its header;
+out-of-range parameters are rejected as format errors, and any in-range combination decrypts normally.
+
 # Details: Encrypted File Format (saltybox format version 1)
+
+NOTE: This section documents the legacy saltybox1 format, which current versions still decrypt but no longer write. New
+files use the saltybox2 format documented above; both formats are specified normatively in `SPEC.md`.
 
 Saltybox encrypts files using a passphrase-based encryption scheme. The output is a text file containing an armored
 (ASCII text) string that represents the encrypted data. This section documents the format.
@@ -122,8 +169,7 @@ Saltybox encrypts files using a passphrase-based encryption scheme. The output i
   ("binary format").
   - Uses URL-safe base64 alphabet: `-` and `_` instead of `+` and `/`
 - Example: `saltybox1:RF0qX8mpCMXVBq6zxHfamdiT64s6Pwvb99Qj9gV61sMAAAAAAAAAFE6RVTWMhBCMJGL0MmgdDUBHoJaW`
-  - The `1` in the prefix indicates the format version. Future versions would use a different version number (e.g.,
-    `saltybox2:`).
+  - The number in the prefix indicates the format version (see the saltybox2 section above for the current format).
 
 ## Binary Format
 
@@ -164,8 +210,9 @@ cargo test --test golden_vectors -- --ignored
 cargo test --test golden_vectors_v2
 ```
 
-(The arguments are required because by default not all golden vectors are tested in order to avoid adding multiple
-seconds to test time.)
+(The extra arguments on the first command are needed because by default only a subset of the v1 vectors is tested:
+saltybox1's scrypt cost is fixed by the format, so every v1 vector is unavoidably slow. saltybox2 records its Argon2
+cost parameters per file, so the v2 vectors are built deliberately cheap and all run by default.)
 
 ## Golden Vectors Format
 
@@ -178,6 +225,11 @@ fields:
 - **salt**: Base64-encoded salt used for encryption
 - **passphrase**: Base64-encoded passphrase used for encryption
 - **comment**: Human-readable description of what the test case exercises
+
+The `testdata/golden-vectors-v2.json` file follows the same conventions with a saltybox2-shaped schema: **armored** (the
+full expected `saltybox2:...` string) instead of **ciphertext**, plus the Argon2 parameters **m_cost_kib**, **t_cost**,
+and **p_cost**. It is generated by `testdata/generate-golden-vectors-v2.py` using an independent implementation stack;
+see `testdata/README`.
 
 All binary data (including passphrases that may contain arbitrary bytes) is base64-encoded for safe JSON storage. The
 ciphertext is in the final armored text format that would be written to a file.

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,9 +26,12 @@ report its path. On Unix the final output file mode is 0600.
 ### encrypt
 
 `saltybox encrypt -i <input> -o <output>` reads plaintext from `<input>` — any byte sequence, including empty — and
-writes one armored saltybox unit to `<output>` in the saltybox1 format. The output format never depends on any existing
-file. Salt and nonce are freshly generated at random for every encryption, so encrypting the same input twice produces
-different output.
+writes one armored saltybox unit to `<output>` in the saltybox2 format, with Argon2 parameters m=262144 KiB, t=3, p=1.
+The output format never depends on any existing file. Salt and nonce are freshly generated at random for every
+encryption, so encrypting the same input twice produces different output.
+
+saltybox1 output cannot be produced: that format is decrypt-only. Consequently, files written by this version cannot be
+read by saltybox versions that predate saltybox2 support.
 
 ### decrypt
 
@@ -68,8 +71,8 @@ with the same classifications (messages may differ in how they name the input fi
 passphrase — aborts the update and leaves `<existing>` unchanged.
 
 On successful validation, the new plaintext is encrypted with the validated passphrase and written atomically over
-`<existing>`, always in the current write format (saltybox1), regardless of the existing file's format: updating a
-saltybox2 file rewrites it as saltybox1 — a format downgrade.
+`<existing>`, always in the current write format (saltybox2), regardless of the existing file's format. Updating a
+saltybox1 file therefore rewrites it as saltybox2: this is the intended migration path for upgrading old files.
 
 ## File formats
 

--- a/src/bin/saltybox.rs
+++ b/src/bin/saltybox.rs
@@ -1,7 +1,8 @@
 //! Saltybox CLI - Passphrase-based file encryption
 //!
-//! Command-line interface for encrypting, decrypting, and updating files using
-//! NaCl secretbox (XSalsa20Poly1305) with scrypt key derivation.
+//! Command-line interface for encrypting, decrypting, and updating files
+//! using the saltybox formats specified in SPEC.md (new files are written as
+//! saltybox2; saltybox1 remains decryptable).
 
 use clap::{Parser, Subcommand};
 use std::error::Error as StdError;

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -390,49 +390,34 @@ mod tests {
         assert_eq!(fs::read(&decrypted_path).unwrap(), b"v2 write path");
     }
 
-    /// The output format follows the write engine alone: updating a v1 file
-    /// with the v2 engine upgrades it, and updating a v2 file with the v1
-    /// engine downgrades it. Both directions must round-trip.
+    /// The output format follows the write engine alone, never the input
+    /// file's format: updating a saltybox1 file with the (v2) default engine
+    /// upgrades it. This is the intended migration path for old files. The
+    /// v1 file is constructed from the frozen v1 modules directly, since
+    /// nothing exposes a v1 write engine anymore.
     #[test]
-    fn test_update_output_format_follows_write_engine_not_input() {
+    fn test_update_upgrades_v1_file_to_default_format() {
         let temp_dir = TempDir::new().unwrap();
         let plain_path = temp_dir.path().join("plain.txt");
         let crypt_path = temp_dir.path().join("crypt.txt.saltybox");
         let decrypted_path = temp_dir.path().join("decrypted.txt");
 
-        fs::write(&plain_path, b"original").unwrap();
-        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
-        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
-        assert!(
-            fs::read_to_string(&crypt_path)
-                .unwrap()
-                .starts_with("saltybox1:")
-        );
+        let v1_armored =
+            crate::varmor::wrap(&crate::secretcrypt_v1::encrypt(b"pw", b"original").unwrap());
+        fs::write(&crypt_path, &v1_armored).unwrap();
 
         fs::write(&plain_path, b"upgraded").unwrap();
-        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
-        update_file(&plain_path, &crypt_path, &mut reader, &V2Engine).unwrap();
-        assert!(
-            fs::read_to_string(&crypt_path)
-                .unwrap()
-                .starts_with("saltybox2:")
-        );
-        let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
-        decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();
-        assert_eq!(fs::read(&decrypted_path).unwrap(), b"upgraded");
-
-        fs::write(&plain_path, b"downgraded").unwrap();
         let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
         update_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
         assert!(
             fs::read_to_string(&crypt_path)
                 .unwrap()
-                .starts_with("saltybox1:")
+                .starts_with("saltybox2:")
         );
 
         let mut reader = ConstantPassphraseReader::new(b"pw".to_vec());
         decrypt_file(&crypt_path, &decrypted_path, &mut reader).unwrap();
-        assert_eq!(fs::read(&decrypted_path).unwrap(), b"downgraded");
+        assert_eq!(fs::read(&decrypted_path).unwrap(), b"upgraded");
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -95,14 +95,17 @@ impl FormatEngine for V1Engine {
 /// Engines are never removed: every format ever written stays decryptable.
 const ENGINES: &[&dyn FormatEngine] = &[&V1Engine, &V2Engine];
 
-/// The engine used for all newly written files.
+/// The engine used for all newly written files: saltybox2.
 ///
 /// The write side has no input magic to dispatch on, so this selection is the
 /// single point that decides what format saltybox produces. Decryption
 /// support is intentionally broader: every engine in `ENGINES` stays
-/// readable forever regardless of what this returns.
+/// readable forever regardless of what this returns. saltybox1 is
+/// decrypt-only — there is deliberately no way to write it from the CLI
+/// (tests exercise the v1 write direction through `secretcrypt_v1`
+/// directly).
 pub fn default_write_engine() -> &'static dyn FormatEngine {
-    &V1Engine
+    &V2Engine
 }
 
 /// Select the engine for an armored input and decode its payload in one step.
@@ -174,17 +177,24 @@ mod tests {
     mod dispatch {
         use super::*;
 
+        /// Produce v1 armored data for read-side tests. The CLI cannot write
+        /// v1, so tests are the only callers of the v1 engine's encrypt —
+        /// routing through it here keeps that impl exercised rather than dead.
+        fn v1_armored(passphrase: &[u8], plaintext: &[u8]) -> String {
+            V1Engine.encrypt(passphrase, plaintext).unwrap()
+        }
+
         #[test]
         fn engine_for_selects_v1() {
-            let armored = default_write_engine().encrypt(b"pw", b"payload").unwrap();
+            let armored = v1_armored(b"pw", b"payload");
             let engine = engine_for(&armored).unwrap();
             assert_eq!(engine.magic(), "saltybox1:");
         }
 
         #[test]
-        fn default_write_engine_writes_v1() {
+        fn default_write_engine_writes_v2() {
             let armored = default_write_engine().encrypt(b"pw", b"payload").unwrap();
-            assert!(armored.starts_with("saltybox1:"));
+            assert!(armored.starts_with("saltybox2:"));
         }
 
         #[test]
@@ -195,9 +205,9 @@ mod tests {
         }
 
         #[test]
-        fn roundtrip_through_dispatch() {
+        fn v1_roundtrip_through_dispatch() {
             let plaintext = b"hello world";
-            let armored = default_write_engine().encrypt(b"pw", plaintext).unwrap();
+            let armored = v1_armored(b"pw", plaintext);
 
             let (engine, payload) = decode(&armored).unwrap();
             let decrypted = engine.decrypt(b"pw", &payload).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Saltybox - Passphrase-based file encryption using NaCl secretbox
+//! Saltybox - Passphrase-based file encryption
 
 #![forbid(unsafe_code)]
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -69,8 +69,7 @@ const V2_FIXTURE: &str = "saltybox2:AAECAwQFBgcICQoLDA0ODwAAIAAAAAADAAAAAQABAgME
 const V2_FIXTURE_PASSPHRASE: &str = "test";
 const V2_FIXTURE_PLAINTEXT: &str = "test payload";
 
-/// Decrypting a saltybox2 file must work unconditionally — no flag or
-/// environment variable involved.
+/// Decrypting a saltybox2 file must work unconditionally.
 #[test]
 fn test_decrypt_known_v2_ciphertext() {
     let temp_dir = TempDir::new().unwrap();
@@ -197,13 +196,10 @@ fn test_update_accepts_v2_encrypted_file() {
         "update over v2 file failed: {}",
         String::from_utf8_lossy(&result.stderr)
     );
-    // Per SPEC.md, update always writes the current write format (saltybox1),
-    // regardless of the existing file's format: updating a saltybox2 file
-    // downgrades it.
     assert!(
         fs::read_to_string(&encrypted)
             .unwrap()
-            .starts_with("saltybox1:")
+            .starts_with("saltybox2:")
     );
 
     let result = run_saltybox_with_passphrase(
@@ -224,11 +220,64 @@ fn test_update_accepts_v2_encrypted_file() {
     );
 }
 
-/// The transition plan (lore/2026-07-01-saltybox2.md) lands saltybox2 read
-/// support before any write-side change: encrypt must keep writing saltybox1
-/// until the default is deliberately flipped in a later step.
+/// Updating a saltybox1 file rewrites it as saltybox2 — the migration path
+/// for pre-existing files. The v1 input comes from the committed fixture,
+/// since the CLI cannot produce saltybox1 output.
 #[test]
-fn test_encrypt_still_writes_saltybox1() {
+fn test_update_upgrades_v1_file_to_saltybox2() {
+    let temp_dir = TempDir::new().unwrap();
+    let new_plain = temp_dir.path().join("new.txt");
+    let encrypted = temp_dir.path().join("hello.txt.salty");
+    let decrypted = temp_dir.path().join("decrypted.txt");
+
+    fs::copy(testdata_path("hello.txt.salty"), &encrypted).unwrap();
+    assert!(
+        fs::read_to_string(&encrypted)
+            .unwrap()
+            .starts_with("saltybox1:")
+    );
+    fs::write(&new_plain, "migrated content").unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "update",
+            "-i",
+            new_plain.to_str().unwrap(),
+            "-o",
+            encrypted.to_str().unwrap(),
+        ],
+        "test",
+    )
+    .unwrap();
+    assert!(
+        result.status.success(),
+        "update over v1 file failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(
+        fs::read_to_string(&encrypted)
+            .unwrap()
+            .starts_with("saltybox2:")
+    );
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "decrypt",
+            "-i",
+            encrypted.to_str().unwrap(),
+            "-o",
+            decrypted.to_str().unwrap(),
+        ],
+        "test",
+    )
+    .unwrap();
+    assert!(result.status.success());
+    assert_eq!(fs::read_to_string(&decrypted).unwrap(), "migrated content");
+}
+
+/// encrypt writes the saltybox2 format.
+#[test]
+fn test_encrypt_writes_saltybox2() {
     let temp_dir = TempDir::new().unwrap();
     let plaintext = temp_dir.path().join("plain.txt");
     let encrypted = temp_dir.path().join("out.salty");
@@ -247,11 +296,9 @@ fn test_encrypt_still_writes_saltybox1() {
     )
     .unwrap();
     assert!(result.status.success());
-    assert!(
-        fs::read_to_string(&encrypted)
-            .unwrap()
-            .starts_with("saltybox1:")
-    );
+    let armored = fs::read_to_string(&encrypted).unwrap();
+    assert!(armored.starts_with("saltybox2:"));
+    assert!(armored.ends_with(":end"));
 }
 
 /// Bare "saltybox2" is a proper prefix of a supported magic and is


### PR DESCRIPTION
## Problem

Final step of lore/2026-07-01-saltybox2.md: saltybox1's crypto parameters (8-byte salt, scrypt at 32 MiB) are dated, and the saltybox2 format (Argon2id + XChaCha20-Poly1305) has been fully implemented, spec'd, and cross-verified in the preceding PRs — but nothing writes it yet.

## Solution

encrypt and update now write saltybox2 unconditionally, and saltybox1 becomes decrypt-only: no write path exists in the CLI, while the v1 code remains in the library so tests keep covering both directions (golden vectors included). update on a saltybox1 file rewrites it as saltybox2 — the intended migration path. Files written from this point cannot be read by older saltybox versions, hence the breaking-change marker; this should release as 4.0.0.

Deviation from the plan: the plan called for an experimental env-var-gated write path to precede this flip. That gate was skipped — no release ships in between, so it could never reach a real user — which makes this PR the single point where write behavior changes.

changelog: include
