### PR TITLE
ci: fail the doc build on rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           toolchain: nightly
           cache: true
+      # rustdoc lint failures are enforced via [lints.rustdoc] in Cargo.toml,
+      # so this fails on e.g. broken intra-doc links without extra flags.
       - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,20 @@ changing behavior, in which case update `SPEC.md` to match as part of the change
 existing-but-unspecified; when a change touches such behavior, specify it (including its pre-existing behavior) in the
 same change.
 
+# Checks
+
+Run the checks CI enforces locally before creating or updating a PR, and again after fixing review findings:
+
+- `cargo fmt -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --all-features --all-targets`
+- `cargo doc --no-deps --all-features`
+- `dprint check`
+
+Plain `cargo doc` suffices for the documentation check: rustdoc's lints (such as public documentation intra-doc-linking
+a private item) are denied via the `[lints.rustdoc]` table in `Cargo.toml`, so they fail the build rather than scrolling
+past as warnings.
+
 # PR titles
 
 PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) style. This is enforced by CI and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,12 @@ zeroize = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+# Deny rustdoc's lints (e.g. public docs intra-doc-linking a private item) so
+# plain `cargo doc` fails on them everywhere — locally and in CI — without
+# anyone having to remember an extra flag or environment variable.
+[lints.rustdoc]
+all = "deny"
+
 # Compile the key-derivation crates with optimizations even in dev/test
 # builds. They are intentionally slow, and for all practical purposes we
 # assume they are not buggy and not under testing.


### PR DESCRIPTION
The doc job already ran cargo doc, but rustdoc warnings (like the private-item intra-doc links caught during review of this stack) only surfaced as PR annotations via the toolchain action's problem matcher — the job stayed green. Enforcement now lives in Cargo.toml's [lints.rustdoc] table (all = "deny"), so plain cargo doc fails on these everywhere — locally and in the existing CI doc job — with no flag or environment variable to remember. AGENTS.md's check list says exactly that. Verified in both directions: the current tree builds docs cleanly, and a deliberately broken private-item link fails the build.

changelog: skip
