### PR TITLE
feat!: reject empty passphrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ same file) is rejected.
   files may remain and should still be private (`0600`).
 - The formats are based upon well known algorithms with exceedingly simple layering on top. New files are written in the
   saltybox2 format (Argon2id for key stretching, XChaCha20-Poly1305 for encryption); older saltybox1 files (scrypt and
-  NaCl secretbox) remain decryptable forever. A base64 variant is used for encoding in both formats.
+  NaCl secretbox) remain decryptable (see the Format/API contract below). A base64 variant is used for encoding in both
+  formats.
 - The amount of code is relatively small and light on dependencies.
 
 # Guidance for use
@@ -93,7 +94,8 @@ external projects/people aside from the Rust language tools themselves remaining
 
 # Format/API contract
 
-- Future versions if any will remain able to decrypt data encrypted by older versions.
+- Future versions if any will remain able to decrypt data encrypted by older versions, with one exception: empty
+  passphrases are rejected, so files encrypted with an empty passphrase by older versions can no longer be decrypted.
 - The reverse does not hold: newly written files use the saltybox2 format, which saltybox versions before 4.0 cannot
   read. Running `update` on an old file also rewrites it as saltybox2 (this is the intended way to migrate old files).
 - The command line interface may change at any time. It is currently not intended for automated scripting (for this

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,7 +12,10 @@ in the same change. `AGENTS.md` states the compliance rule.
 
 All commands take a passphrase: interactively from the terminal with echo disabled, or — when the global
 `--passphrase-stdin` option is given — from standard input, read to end-of-input and used exactly as provided (trailing
-newlines are NOT stripped, and the passphrase need not be valid UTF-8). On any failure, commands exit with a nonzero
+newlines are NOT stripped, and the passphrase need not be valid UTF-8). An empty passphrase is an error for every
+command, regardless of how the passphrase was provided: it offers no meaningful protection, and empty input almost
+always means a mistake (an unset shell variable expands to empty) rather than intent. NOTE: this makes files encrypted
+with an empty passphrase by older versions undecryptable by these commands. On any failure, commands exit with a nonzero
 status and report the error on standard error.
 
 Commands write their output file atomically via a same-directory private temporary file: on success the output contains

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum ErrorKind {
     AuthenticationFailed,
     /// Passphrase could not be obtained from the configured reader.
     PassphraseUnavailable,
+    /// The passphrase read was empty. Empty passphrases are rejected for all
+    /// operations: they provide no meaningful protection, and empty input is
+    /// almost always an accident (an unset shell variable expands to empty).
+    EmptyPassphrase,
     /// Low-level scrypt key derivation failed.
     ScryptFailure,
     /// Low-level Argon2 key derivation failed.

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -14,6 +14,29 @@ use zeroize::Zeroizing;
 const TEMPFILE_PREFIX: &str = ".saltybox-";
 const TEMPFILE_SUFFIX: &str = ".tmp";
 
+/// Reads the passphrase and rejects an empty one.
+///
+/// Empty passphrases are refused for all operations. An empty passphrase
+/// provides no meaningful protection, and empty input is almost always an
+/// accident rather than intent — the canonical case is `--passphrase-stdin`
+/// fed by `echo -n "$PASS"` with `PASS` unset, which expands to zero bytes
+/// and would otherwise silently produce an effectively unprotected file.
+///
+/// The check lives here at the operation layer, not in the individual
+/// [`PassphraseReader`] implementations, so it holds regardless of how the
+/// passphrase was obtained.
+fn read_nonempty_passphrase(reader: &mut dyn PassphraseReader) -> Result<Zeroizing<Vec<u8>>> {
+    let passphrase = reader.read_passphrase()?;
+    if passphrase.is_empty() {
+        return Err(SaltyboxError::with_kind(
+            ErrorCategory::User,
+            ErrorKind::EmptyPassphrase,
+            "empty passphrase is not allowed (note that an unset shell variable expands to empty)",
+        ));
+    }
+    Ok(passphrase)
+}
+
 /// Encrypt a file with a passphrase
 ///
 /// Reads plaintext from `input_path`, encrypts it using a passphrase from
@@ -31,7 +54,7 @@ pub fn encrypt_file(
     write_engine: &dyn format::FormatEngine,
 ) -> Result<()> {
     let plaintext = Zeroizing::new(fs::read(input_path).map_err(|e| read_error(input_path, e))?);
-    let passphrase = passphrase_reader.read_passphrase()?;
+    let passphrase = read_nonempty_passphrase(passphrase_reader)?;
     let armored = write_engine
         .encrypt(&passphrase, &plaintext)
         .map_err(|e| e.with_context("encryption failed"))?;
@@ -62,7 +85,7 @@ pub fn decrypt_file(
             e,
         )
     })?;
-    let passphrase = passphrase_reader.read_passphrase()?;
+    let passphrase = read_nonempty_passphrase(passphrase_reader)?;
     let (engine, ciphertext) =
         format::decode(&armored).map_err(|e| e.with_context("failed to unarmor"))?;
     let plaintext = engine
@@ -113,7 +136,7 @@ pub fn update_file(
             e,
         )
     })?;
-    let passphrase = passphrase_reader.read_passphrase()?;
+    let passphrase = read_nonempty_passphrase(passphrase_reader)?;
 
     // Validate passphrase by decrypting existing file (discard plaintext)
     let (engine, ciphertext) =
@@ -832,6 +855,42 @@ mod tests {
         assert_eq!(err.kind, Some(ErrorKind::Io));
         assert_eq!(err.message(), "encrypted file is not valid UTF-8");
         assert_eq!(fs::read(&crypt_path).unwrap(), [0xff]);
+    }
+
+    /// Empty passphrases are rejected by every operation, including decrypt:
+    /// SPEC.md makes files encrypted with an empty passphrase (possible in
+    /// older versions) deliberately undecryptable.
+    #[test]
+    fn test_empty_passphrase_is_rejected_by_all_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let plain_path = temp_dir.path().join("plain.txt");
+        let crypt_path = temp_dir.path().join("crypt.txt.saltybox");
+        let decrypted_path = temp_dir.path().join("decrypted.txt");
+
+        fs::write(&plain_path, b"secret").unwrap();
+
+        let mut reader = ConstantPassphraseReader::new(b"".to_vec());
+        let err = encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader)
+            .expect_err("expected empty passphrase rejection on encrypt");
+        assert_eq!(err.category, ErrorCategory::User);
+        assert_eq!(err.kind, Some(ErrorKind::EmptyPassphrase));
+        assert!(!crypt_path.exists());
+
+        // Set up a real encrypted file so decrypt/update fail on the
+        // passphrase check, not on a missing input.
+        let mut reader = ConstantPassphraseReader::new(b"real passphrase".to_vec());
+        encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader).unwrap();
+
+        let mut reader = ConstantPassphraseReader::new(b"".to_vec());
+        let err = decrypt_file(&crypt_path, &decrypted_path, &mut reader)
+            .expect_err("expected empty passphrase rejection on decrypt");
+        assert_eq!(err.kind, Some(ErrorKind::EmptyPassphrase));
+        assert!(!decrypted_path.exists());
+
+        let mut reader = ConstantPassphraseReader::new(b"".to_vec());
+        let err = update_with_default_engine(&plain_path, &crypt_path, &mut reader)
+            .expect_err("expected empty passphrase rejection on update");
+        assert_eq!(err.kind, Some(ErrorKind::EmptyPassphrase));
     }
 
     #[test]

--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -143,6 +143,10 @@ mod tests {
         assert_eq!(&*reader.read_passphrase().unwrap(), b"mypassword");
     }
 
+    /// Readers pass an empty passphrase through unmodified: rejecting empty
+    /// passphrases is the operation layer's job (see `file_ops`), so it holds
+    /// for every reader implementation rather than being re-enforced (or
+    /// forgotten) per source.
     #[test]
     fn test_reader_passphrase_reader_empty() {
         let data = b"";

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -605,6 +605,38 @@ fn test_passphrase_stdin_preserves_trailing_newline() {
     );
 }
 
+/// An empty passphrase is rejected (SPEC.md). The common way to arrive here
+/// is `echo -n "$PASS"` on --passphrase-stdin with PASS unset, which would
+/// otherwise silently produce a file protected by nothing.
+#[test]
+fn test_rejects_empty_passphrase() {
+    let temp_dir = TempDir::new().unwrap();
+    let plaintext = temp_dir.path().join("plaintext.txt");
+    let encrypted = temp_dir.path().join("encrypted.txt.salty");
+
+    fs::write(&plaintext, "secret").unwrap();
+
+    let result = run_saltybox_with_passphrase(
+        &[
+            "encrypt",
+            "-i",
+            plaintext.to_str().unwrap(),
+            "-o",
+            encrypted.to_str().unwrap(),
+        ],
+        "",
+    )
+    .unwrap();
+
+    assert!(!result.status.success());
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("empty passphrase is not allowed"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(!encrypted.exists());
+}
+
 #[test]
 fn test_update_operation() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
An empty passphrase provides no meaningful protection, and empty input is almost always an accident rather than intent: the canonical case is `--passphrase-stdin` fed by `echo -n "$PASS"` with `PASS` unset, which expands to zero bytes and silently produced an effectively unprotected file.

Rejection happens at the operation layer (`file_ops`) so it holds for every passphrase source; the format engines still accept empty passphrases, keeping the v1 golden vector valid.

Breaking: files encrypted with an empty passphrase by older versions can no longer be decrypted or updated.

changelog: include
