### PR TITLE
fix: avoid unwiped passphrase copies from buffer growth

### DIFF
--- a/src/passphrase.rs
+++ b/src/passphrase.rs
@@ -6,10 +6,15 @@ use zeroize::Zeroizing;
 
 /// Trait for reading passphrases from various sources
 pub trait PassphraseReader {
-    /// Read a passphrase as arbitrary bytes (not necessarily UTF-8)
+    /// Read a passphrase as arbitrary bytes (not necessarily UTF-8).
     ///
-    /// Returns the passphrase wrapped in `Zeroizing` to ensure it is securely
-    /// wiped from memory when dropped.
+    /// The returned buffer is wrapped in `Zeroizing`, which wipes it on drop.
+    /// This is best-effort hardening against casual exposure (core dumps,
+    /// swap, reused heap), not a guarantee that no copy of the passphrase
+    /// remains in memory: an implementation cannot wipe copies made before
+    /// the bytes reach the returned buffer — intermediate allocations,
+    /// third-party library internals, kernel tty and pipe buffers. Each
+    /// implementation documents what its wipe does and does not cover.
     fn read_passphrase(&mut self) -> Result<Zeroizing<Vec<u8>>>;
 }
 
@@ -35,6 +40,17 @@ impl PassphraseReader for ConstantPassphraseReader {
     }
 }
 
+/// Pre-reserved capacity for the passphrase buffer.
+///
+/// `Zeroizing` only wipes the buffer the `Vec` holds at drop time. If
+/// `read_to_end` outgrows the allocation, the old buffer is freed without
+/// being wiped, stranding a passphrase prefix in freed heap. Reserving more
+/// than any realistic passphrase up front means the buffer never grows, so
+/// the drop-time wipe covers the only copy this process made. Longer input
+/// still works — this is not a length limit — it merely degrades to the
+/// best-effort behavior described on [`PassphraseReader`].
+const PASSPHRASE_BUFFER_CAPACITY: usize = 4096;
+
 /// Reads passphrase from any io::Read source
 pub struct ReaderPassphraseReader {
     reader: Box<dyn Read>,
@@ -47,8 +63,21 @@ impl ReaderPassphraseReader {
 }
 
 impl PassphraseReader for ReaderPassphraseReader {
+    /// Reads all bytes until end-of-input.
+    ///
+    /// For input smaller than `PASSPHRASE_BUFFER_CAPACITY`, this
+    /// implementation makes no unwiped copy of its own: `read_to_end` reads
+    /// directly into the pre-reserved spare capacity without reallocating.
+    /// What the wrapped reader does internally is outside this type's
+    /// control — wrapping the source in a `BufReader`, for example, would
+    /// stage bytes in a buffer that never gets wiped. The reader the CLI
+    /// passes here is `std::io::stdin()`, whose `read_to_end` delegates to
+    /// the underlying fd rather than staging bytes in its `BufReader`
+    /// (verified against std's implementation as of Rust 1.93; if that
+    /// drifts, the result is an unwiped copy, not incorrect behavior).
+    /// Kernel pipe buffers hold a copy regardless.
     fn read_passphrase(&mut self) -> Result<Zeroizing<Vec<u8>>> {
-        let mut data = Zeroizing::new(Vec::new());
+        let mut data = Zeroizing::new(Vec::with_capacity(PASSPHRASE_BUFFER_CAPACITY));
         self.reader.read_to_end(&mut data).map_err(|e| {
             SaltyboxError::with_kind_and_source(
                 ErrorCategory::Internal,
@@ -96,8 +125,11 @@ impl PassphraseReader for TerminalPassphraseReader {
             )
         })?;
 
-        // Read password *without echo*
-        // Note: rpassword returns String (UTF-8 only), not zeroized
+        // Read without echo. rpassword returns a plain String; the
+        // into_bytes below hands its buffer to Zeroizing without copying, so
+        // the final buffer does get wiped — but any intermediate buffers
+        // rpassword used while assembling the line are its own, and we
+        // cannot wipe those.
         let passphrase = rpassword::read_password().map_err(|e| {
             SaltyboxError::with_kind_and_source(
                 ErrorCategory::Internal,
@@ -152,6 +184,29 @@ mod tests {
         let data = b"";
         let mut reader = ReaderPassphraseReader::new(Box::new(&data[..]));
         assert_eq!(&*reader.read_passphrase().unwrap(), b"");
+    }
+
+    /// Guards the property the preallocation exists for: a realistic-size
+    /// passphrase is read without growing the buffer, so the drop-time wipe
+    /// covers the only copy this process makes. If the returned capacity is
+    /// not the pre-reserved one, the buffer was reallocated and an unwiped
+    /// prefix was stranded in freed heap — the bug the preallocation fixed.
+    #[test]
+    fn test_reader_passphrase_reader_small_input_does_not_reallocate() {
+        let data = b"a realistic passphrase";
+        let mut reader = ReaderPassphraseReader::new(Box::new(&data[..]));
+        let passphrase = reader.read_passphrase().unwrap();
+        assert_eq!(&**passphrase, data);
+        assert_eq!(passphrase.capacity(), PASSPHRASE_BUFFER_CAPACITY);
+    }
+
+    /// Input larger than the pre-reserved buffer capacity must still be
+    /// accepted: the preallocation is memory hygiene, not a length limit.
+    #[test]
+    fn test_reader_passphrase_reader_larger_than_prealloc() {
+        let data = vec![0x42u8; PASSPHRASE_BUFFER_CAPACITY * 2];
+        let mut reader = ReaderPassphraseReader::new(Box::new(std::io::Cursor::new(data.clone())));
+        assert_eq!(&**reader.read_passphrase().unwrap(), &data[..]);
     }
 
     /// Verifies that ReaderPassphraseReader accepts arbitrary byte sequences,


### PR DESCRIPTION
`Zeroizing` only wipes the buffer the `Vec` holds at drop time. Reading the passphrase into an initially-empty `Vec` grew it by reallocation, freeing each earlier buffer unwiped and stranding passphrase prefixes in freed heap. Pre-reserving more than any realistic passphrase means the buffer never grows, so the drop-time wipe covers the only userspace copy the process makes (verified against std's `read_to_end` and stdin `BufReader` delegation as of Rust 1.93). Oversized input still works; it degrades to the previous best-effort behavior rather than hitting a length cap.

The passphrase docstrings also promised more than the code delivered ("securely wiped from memory"); they now state the calibrated contract: best-effort hardening against casual exposure, with rpassword internals and kernel buffers explicitly out of scope.

changelog: include
