### PR TITLE
fix: report pre-write directory open failures accurately

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -24,7 +24,9 @@ before the atomic rename, an existing file at the output path is left unchanged.
 failure": if making the rename durable fails after the rename itself succeeded, the output has already been replaced —
 with complete contents — while the command still exits nonzero.) A failed or interrupted write may leave the temporary
 file (on Unix with owner-only permissions; name prefixed `.saltybox-`) behind in the output directory; rename failures
-report its path. On Unix the final output file mode is 0600.
+report its path. Failures before the temporary file is created (such as an unusable output directory) leave nothing
+behind and are reported without implying a write took place; a nonexistent output directory is reported as such. On Unix
+the final output file mode is 0600.
 
 ### encrypt
 

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -209,14 +209,15 @@ fn write_file_secure(path: &Path, contents: &[u8]) -> Result<()> {
     };
     #[cfg(unix)]
     let output_dir_file = fs::File::open(output_dir).map_err(|e| {
-        // A missing directory is a user mistake (typoed output path) and gets
-        // a message saying so; the sync-framed message would mislead by
-        // implying the file had already been written.
+        // This open happens before anything is written, so neither message may
+        // imply a write occurred. A missing directory is additionally a user
+        // mistake (typoed output path) and gets a message saying so.
         let msg = if e.kind() == io::ErrorKind::NotFound {
             format!("output directory {} does not exist", output_dir.display())
         } else {
             format!(
-                "failed to open output directory for syncing after writing {}",
+                "failed to open output directory {} while preparing to write {}",
+                output_dir.display(),
                 path.display()
             )
         };
@@ -696,6 +697,67 @@ mod tests {
 
         result.expect_err("expected decrypt output write to fail");
         assert_eq!(fs::read(&decrypted_path).unwrap(), b"old plaintext");
+    }
+
+    /// Pins the pre-write framing SPEC.md makes normative for failures
+    /// before the tempfile exists: an output directory that cannot be opened
+    /// (mode 0o000 here, so EACCES rather than the specially-handled
+    /// NotFound) must be reported as a failure while preparing to write. The
+    /// pre-fix message claimed the file had already been written, sending
+    /// users hunting for output that never existed. (SPEC's "leave nothing
+    /// behind" clause is not asserted here: with the directory unwritable,
+    /// no implementation could leave anything behind, so such an assertion
+    /// would be vacuous.)
+    #[test]
+    #[cfg(unix)]
+    fn test_unopenable_output_directory_reports_pre_write_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = temp_dir.path().join("output");
+        let plain_path = temp_dir.path().join("plain.txt");
+        let crypt_path = output_dir.join("crypt.txt.saltybox");
+
+        fs::create_dir(&output_dir).unwrap();
+        fs::write(&plain_path, b"secret").unwrap();
+
+        let original_permissions = fs::metadata(&output_dir).unwrap().permissions();
+        let mut unopenable_permissions = original_permissions.clone();
+        unopenable_permissions.set_mode(0o000);
+        fs::set_permissions(&output_dir, unopenable_permissions).unwrap();
+
+        // Root ignores directory permissions; skip rather than assert a
+        // failure that cannot happen (same pattern as the write-failure test
+        // above).
+        if fs::File::open(&output_dir).is_ok() {
+            fs::set_permissions(&output_dir, original_permissions).unwrap();
+            eprintln!(
+                "skipping unopenable-directory assertion because this process can still open it"
+            );
+            return;
+        }
+
+        let mut reader = ConstantPassphraseReader::new(b"test".to_vec());
+        let result = encrypt_with_default_engine(&plain_path, &crypt_path, &mut reader);
+
+        fs::set_permissions(&output_dir, original_permissions).unwrap();
+
+        let err = result.expect_err("expected unopenable output directory to fail");
+        let mut found_pre_write_framing = false;
+        let mut source: Option<&(dyn std::error::Error + 'static)> = Some(&err);
+        while let Some(e) = source {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("after writing"),
+                "message must not claim a write happened: {msg}"
+            );
+            if msg.contains("while preparing to write") {
+                found_pre_write_framing = true;
+            }
+            source = e.source();
+        }
+        assert!(
+            found_pre_write_framing,
+            "expected the pre-write framing in the error chain"
+        );
     }
 
     /// Pins the tempfile contract SPEC.md makes normative: the temporary


### PR DESCRIPTION
write_file_secure opens the output directory before creating the
tempfile, but non-NotFound open failures (EACCES, ENOTDIR, ...) were
reported as "failed to open output directory for syncing after
writing", claiming a write that never happened. Someone debugging such
a failure would go looking for a file that does not exist. Reframe the
message as the pre-write failure it is; the missing-directory special
case already said the right thing.

SPEC.md's atomic-write section gains a sentence pinning this behavior
(failures before the tempfile is created leave nothing behind and do
not claim a write), and a test now exercises the previously untested
non-NotFound branch against that contract.

changelog: include
