### PR TITLE
ci: drop nonexistent branches from push triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      - master
-      - develop
 
 # CI only needs to read the repo. Without this, third-party actions run with
 # whatever the repository default GITHUB_TOKEN grants.


### PR DESCRIPTION
The push trigger listed master and develop, but neither branch exists
on the remote and the test-linux/golden-vectors jobs gate on main
anyway. A push to either branch would have run only the lint jobs and
reported green with the entire test suite silently skipped. Trigger on
main alone, matching the branches that actually exist and the gates
the jobs already enforce.

changelog: skip
