### PR TITLE
chore: remove retired dependabot reviewers key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 0
-    reviewers:
-      - "scode"


### PR DESCRIPTION
GitHub retired the dependabot reviewers option on 2025-05-20 and
silently ignores it since, so the key is dead configuration:

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

The rest of the block stays: open-pull-requests-limit 0 is the
documented way to keep security-update PRs while disabling version
updates. If reviewer assignment on those PRs is wanted again, the
replacement is a CODEOWNERS file.

changelog: skip
